### PR TITLE
S3 display events on map

### DIFF
--- a/app/src/androidTest/java/com/github/se/gomeet/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/navigation/NavigationTest.kt
@@ -28,7 +28,9 @@ class NavigationTest {
     composeTestRule.setContent {
       val nav = rememberNavController()
       NavHost(navController = nav, startDestination = Route.EVENTS) {
-        composable(TOP_LEVEL_DESTINATIONS[0].route) { Explore(nav = NavigationActions(nav)) }
+        composable(TOP_LEVEL_DESTINATIONS[0].route) {
+          Explore(nav = NavigationActions(nav), EventViewModel())
+        }
         composable(TOP_LEVEL_DESTINATIONS[1].route) {
           Events(NavigationActions(nav), EventViewModel())
         }
@@ -53,7 +55,9 @@ class NavigationTest {
     composeTestRule.setContent {
       val nav = rememberNavController()
       NavHost(navController = nav, startDestination = TOP_LEVEL_DESTINATIONS[0].route) {
-        composable(TOP_LEVEL_DESTINATIONS[0].route) { Explore(nav = NavigationActions(nav)) }
+        composable(TOP_LEVEL_DESTINATIONS[0].route) {
+          Explore(nav = NavigationActions(nav), EventViewModel())
+        }
         composable(TOP_LEVEL_DESTINATIONS[1].route) {
           Events(NavigationActions(nav), EventViewModel())
         }

--- a/app/src/main/java/com/github/se/gomeet/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gomeet/EventFirebaseConnection.kt
@@ -112,7 +112,7 @@ class EventFirebaseConnection(private val db: FirebaseFirestore) {
         url = this["url"] as String,
         participants = this["participants"] as List<String>,
         visibleToIfPrivate = this["visibleToIfPrivate"] as List<String>,
-        maxParticipants = this["maxParticipants"] as Int,
+        maxParticipants = this["maxParticipants"].toString().toInt(),
         public = this["public"] as Boolean,
         tags = this["tags"] as List<String>,
         images = this["images"] as List<String>)

--- a/app/src/main/java/com/github/se/gomeet/MainActivity.kt
+++ b/app/src/main/java/com/github/se/gomeet/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : ComponentActivity() {
                 NavigationActions(nav).navigateTo(TOP_LEVEL_DESTINATIONS[1])
               }
             }
-            composable(Route.EXPLORE) { Explore(navAction) }
+            composable(Route.EXPLORE) { Explore(navAction, EventViewModel()) }
             composable(Route.EVENTS) { Events(navAction, EventViewModel()) }
             composable(Route.TRENDS) { Trends(navAction) }
             composable(Route.CREATE) { Create(navAction) }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
@@ -45,7 +45,7 @@ fun Explore(nav: NavigationActions, eventViewModel: EventViewModel) {
     coroutineScope.launch {
       val allEvents = eventViewModel.getAllEvents()
       if (allEvents != null) {
-          eventList.addAll(allEvents)
+        eventList.addAll(allEvents)
       }
       isMapLoaded = true
     }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
@@ -43,7 +43,10 @@ fun Explore(nav: NavigationActions, eventViewModel: EventViewModel) {
 
   LaunchedEffect(Unit) {
     coroutineScope.launch {
-      eventList.addAll(eventViewModel.getAllEvents()!!)
+      val allEvents = eventViewModel.getAllEvents()
+      if (allEvents != null) {
+          eventList.addAll(allEvents)
+      }
       isMapLoaded = true
     }
   }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
@@ -4,25 +4,50 @@ import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.github.se.gomeet.model.event.Event
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.ui.navigation.Route
 import com.github.se.gomeet.ui.navigation.TOP_LEVEL_DESTINATIONS
+import com.github.se.gomeet.viewmodel.EventViewModel
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
 import com.google.maps.android.compose.CameraPositionState
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.MarkerInfoWindowContent
 import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberMarkerState
+import kotlinx.coroutines.launch
 
 @Composable
-fun Explore(nav: NavigationActions) {
+fun Explore(nav: NavigationActions, eventViewModel: EventViewModel) {
   Log.d("Explore", "Back in Explore")
+  val coroutineScope = rememberCoroutineScope()
+
+  var isMapLoaded by remember { mutableStateOf(false) }
+  val eventList = remember { mutableListOf<Event>() }
+
+  LaunchedEffect(Unit) {
+    coroutineScope.launch {
+      eventList.addAll(eventViewModel.getAllEvents()!!)
+      isMapLoaded = true
+    }
+  }
+
   Scaffold(
       bottomBar = {
         BottomNavigationMenu(
@@ -32,7 +57,11 @@ fun Explore(nav: NavigationActions) {
             tabList = TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.EXPLORE)
       }) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) { GoogleMapView() }
+        Box(modifier = Modifier.padding(innerPadding)) {
+          if (isMapLoaded) {
+            GoogleMapView(events = eventList)
+          }
+        }
       }
 }
 
@@ -42,7 +71,11 @@ fun GoogleMapView(
     cameraPositionState: CameraPositionState = rememberCameraPositionState(),
     onMapLoaded: () -> Unit = {},
     content: @Composable () -> Unit = {},
+    events: List<Event>
 ) {
+
+  val locations = events.map { event -> LatLng(event.location.latitude, event.location.longitude) }
+  val states = locations.map { location -> rememberMarkerState(position = location) }
 
   val uiSettings by remember {
     mutableStateOf(MapUiSettings(compassEnabled = false, zoomControlsEnabled = false))
@@ -58,6 +91,18 @@ fun GoogleMapView(
         uiSettings = uiSettings,
         onMapLoaded = onMapLoaded,
         onPOIClick = {}) {
+          val markerClick: (Marker) -> Boolean = { false }
+
+          for (i in states.indices) {
+            MarkerInfoWindowContent(
+                state = states[i],
+                title = events[i].title,
+                icon = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED),
+                onClick = markerClick,
+            ) {
+              Text(it.title!!, color = Color.Black)
+            }
+          }
           content()
         }
   }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
@@ -39,7 +39,7 @@ fun Explore(nav: NavigationActions, eventViewModel: EventViewModel) {
   val coroutineScope = rememberCoroutineScope()
 
   var isMapLoaded by remember { mutableStateOf(false) }
-  val eventList = remember { mutableListOf<Event>() }
+  var eventList = remember { mutableListOf<Event>() }
 
   LaunchedEffect(Unit) {
     coroutineScope.launch {

--- a/app/src/main/java/com/github/se/gomeet/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/github/se/gomeet/viewmodel/EventViewModel.kt
@@ -30,6 +30,16 @@ class EventViewModel(private val creatorId: String? = null) : ViewModel() {
     }
   }
 
+  suspend fun getAllEvents(): List<Event>? {
+    return try {
+      val event = CompletableDeferred<List<Event>?>()
+      db.getAllEvents { t -> event.complete(t) }
+      event.await()
+    } catch (e: Exception) {
+      null
+    }
+  }
+
   fun createEvent(
       title: String,
       description: String,


### PR DESCRIPTION
Made the following changes:

- Explore.kt: Added an EventViewModel parameter so the class can have access to the list of events, and the map can now display the location of events. There are still improvements that should be done in the future: 1) The map should only display nearby events instead of all the events in the database. 2) Change the markers (currently using the default ones). 3) Clicking on an event should open the event page instead of just showing the event's title.

- NavigationTest.kt and MainActivity.kt: Added the EventViewModel parameter when calling Explore.

- EventViewModel.kt: Added a function to get all events from the database.

- EventFirebaseConnection.kt: Changed a line that caused the app to crash when retrieving events from the database.