### PR TITLE
S4 Added the Add Participants button in the Create Private Event screen

### DIFF
--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/create/CreateEventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/create/CreateEventTest.kt
@@ -47,6 +47,8 @@ class CreateEventTest {
     // Enter a URL
     rule.onNodeWithText("Link").performTextInput("http://example.com")
 
+    rule.onNodeWithText("Add Participants").assertIsDisplayed()
+
     rule.onNodeWithText("Add Image").assertIsDisplayed()
 
     rule.onNodeWithText("Post").performClick()

--- a/app/src/main/java/com/github/se/gomeet/MainActivity.kt
+++ b/app/src/main/java/com/github/se/gomeet/MainActivity.kt
@@ -19,6 +19,7 @@ import com.github.se.gomeet.ui.mainscreens.Events
 import com.github.se.gomeet.ui.mainscreens.Explore
 import com.github.se.gomeet.ui.mainscreens.Profile
 import com.github.se.gomeet.ui.mainscreens.Trends
+import com.github.se.gomeet.ui.mainscreens.create.AddParticipants
 import com.github.se.gomeet.ui.mainscreens.create.Create
 import com.github.se.gomeet.ui.mainscreens.create.CreateEvent
 import com.github.se.gomeet.ui.mainscreens.profile.OthersProfile
@@ -85,6 +86,9 @@ class MainActivity : ComponentActivity() {
             }
             composable(Route.PUBLIC_CREATE) {
               CreateEvent(navAction, EventViewModel(userIdState.value), false)
+            }
+            composable(Route.ADD_PARTICIPANTS) {
+                AddParticipants(navAction)
             }
           }
         }

--- a/app/src/main/java/com/github/se/gomeet/MainActivity.kt
+++ b/app/src/main/java/com/github/se/gomeet/MainActivity.kt
@@ -87,9 +87,7 @@ class MainActivity : ComponentActivity() {
             composable(Route.PUBLIC_CREATE) {
               CreateEvent(navAction, EventViewModel(userIdState.value), false)
             }
-            composable(Route.ADD_PARTICIPANTS) {
-                AddParticipants(navAction)
-            }
+            composable(Route.ADD_PARTICIPANTS) { AddParticipants(navAction) }
           }
         }
       }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/AddParticipants.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/AddParticipants.kt
@@ -13,19 +13,19 @@ import com.github.se.gomeet.ui.navigation.TOP_LEVEL_DESTINATIONS
 
 @Composable
 fun AddParticipants(nav: NavigationActions) {
-    /* TODO: Code the UI of the AddParticipants screen when the logic of
-    the invites will be done and the UI of this screen discussed with the team */
+  /* TODO: Code the UI of the AddParticipants screen when the logic of
+  the invites will be done and the UI of this screen discussed with the team */
 
-    Scaffold(
-        modifier = Modifier.testTag("AddParticipantsScreen"),
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { selectedTab ->
-                    nav.navigateTo(TOP_LEVEL_DESTINATIONS.first { it.route == selectedTab })
-                },
-                tabList = TOP_LEVEL_DESTINATIONS,
-                selectedItem = Route.CREATE)
-        }) { innerPadding ->
+  Scaffold(
+      modifier = Modifier.testTag("AddParticipantsScreen"),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { selectedTab ->
+              nav.navigateTo(TOP_LEVEL_DESTINATIONS.first { it.route == selectedTab })
+            },
+            tabList = TOP_LEVEL_DESTINATIONS,
+            selectedItem = Route.CREATE)
+      }) { innerPadding ->
         Text("Add Participants", Modifier.padding(innerPadding))
-    }
+      }
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/AddParticipants.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/AddParticipants.kt
@@ -1,0 +1,31 @@
+package com.github.se.gomeet.ui.mainscreens.create
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
+import com.github.se.gomeet.ui.navigation.NavigationActions
+import com.github.se.gomeet.ui.navigation.Route
+import com.github.se.gomeet.ui.navigation.TOP_LEVEL_DESTINATIONS
+
+@Composable
+fun AddParticipants(nav: NavigationActions) {
+    /* TODO: Code the UI of the AddParticipants screen when the logic of
+    the invites will be done and the UI of this screen discussed with the team */
+
+    Scaffold(
+        modifier = Modifier.testTag("AddParticipantsScreen"),
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { selectedTab ->
+                    nav.navigateTo(TOP_LEVEL_DESTINATIONS.first { it.route == selectedTab })
+                },
+                tabList = TOP_LEVEL_DESTINATIONS,
+                selectedItem = Route.CREATE)
+        }) { innerPadding ->
+        Text("Add Participants", Modifier.padding(innerPadding))
+    }
+}

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material3.Button
@@ -48,6 +50,7 @@ import com.github.se.gomeet.R
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.ui.navigation.Route
+import com.github.se.gomeet.ui.navigation.SECOND_LEVEL_DESTINATION
 import com.github.se.gomeet.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.github.se.gomeet.ui.theme.DarkCyan
 import com.github.se.gomeet.ui.theme.Grey
@@ -137,7 +140,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
         }
 
         Column(
-            Modifier.padding(innerPadding),
+            Modifier.padding(innerPadding).verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
               Spacer(modifier = Modifier.size((LocalConfiguration.current.screenHeightDp / 9).dp))
@@ -155,7 +158,10 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Title"))
+                  Modifier
+                      .fillMaxWidth()
+                      .padding(start = 7.dp, end = 7.dp)
+                      .testTag("Title"))
 
               OutlinedTextField(
                   value = descriptionState.value,
@@ -170,9 +176,10 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                      Modifier.fillMaxWidth()
-                          .padding(start = 7.dp, end = 7.dp)
-                          .testTag("Description"))
+                  Modifier
+                      .fillMaxWidth()
+                      .padding(start = 7.dp, end = 7.dp)
+                      .testTag("Description"))
 
               OutlinedTextField(
                   value = locationState.value,
@@ -187,7 +194,10 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Location"))
+                  Modifier
+                      .fillMaxWidth()
+                      .padding(start = 7.dp, end = 7.dp)
+                      .testTag("Location"))
 
               OutlinedTextField(
                   value = textDate.value,
@@ -210,7 +220,10 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Date"))
+                  Modifier
+                      .fillMaxWidth()
+                      .padding(start = 7.dp, end = 7.dp)
+                      .testTag("Date"))
 
               OutlinedTextField(
                   value = priceText,
@@ -228,7 +241,10 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Price"))
+                  Modifier
+                      .fillMaxWidth()
+                      .padding(start = 7.dp, end = 7.dp)
+                      .testTag("Price"))
 
               OutlinedTextField(
                   value = url.value,
@@ -242,10 +258,31 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Link"))
+                  Modifier
+                      .fillMaxWidth()
+                      .padding(start = 7.dp, end = 7.dp)
+                      .testTag("Link"))
+
+            if (isPrivate) {
+                Button(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(7.dp),
+                    onClick = {
+                        nav.navigateTo(SECOND_LEVEL_DESTINATION.first { it.route == Route.ADD_PARTICIPANTS })
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Grey),
+                    shape = RoundedCornerShape(10.dp)) {
+                    Text(
+                        text = "Add Participants",
+                        color = Color.White)
+                }
+            }
 
               Button(
-                  modifier = Modifier.fillMaxWidth().padding(7.dp),
+                  modifier = Modifier
+                      .fillMaxWidth()
+                      .padding(7.dp),
                   onClick = {
                     if (imageUri != null) {
                       imageUri = null

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -35,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -98,41 +96,41 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
   Scaffold(
       modifier = Modifier.testTag("CreateEvent"),
       topBar = {
-          Column {
-              Text(
-                  text = "Create",
-                  modifier = Modifier.padding(horizontal = 15.dp, vertical = 15.dp),
-                  color = DarkCyan,
-                  fontStyle = FontStyle.Normal,
-                  fontWeight = FontWeight.SemiBold,
-                  fontFamily = FontFamily.Default,
-                  textAlign = TextAlign.Start,
-                  style = MaterialTheme.typography.headlineLarge)
+        Column {
+          Text(
+              text = "Create",
+              modifier = Modifier.padding(top = 15.dp, start = 15.dp, end = 18.dp, bottom = 0.dp),
+              color = DarkCyan,
+              fontStyle = FontStyle.Normal,
+              fontWeight = FontWeight.SemiBold,
+              fontFamily = FontFamily.Default,
+              textAlign = TextAlign.Start,
+              style = MaterialTheme.typography.headlineLarge)
 
-              if (isPrivate) {
-                  isPrivateEvent.value = true
-                  Text(
-                      text = "Private",
-                      modifier = Modifier.padding(horizontal = 18.dp),
-                      color = Grey,
-                      fontStyle = FontStyle.Normal,
-                      fontWeight = FontWeight.SemiBold,
-                      fontFamily = FontFamily.Default,
-                      textAlign = TextAlign.Start,
-                      style = MaterialTheme.typography.titleSmall)
-              } else {
-                  isPrivateEvent.value = false
-                  Text(
-                      text = "Public",
-                      modifier = Modifier.padding(horizontal = 18.dp),
-                      color = Grey,
-                      fontStyle = FontStyle.Normal,
-                      fontWeight = FontWeight.SemiBold,
-                      fontFamily = FontFamily.Default,
-                      textAlign = TextAlign.Start,
-                      style = MaterialTheme.typography.titleSmall)
-              }
+          if (isPrivate) {
+            isPrivateEvent.value = true
+            Text(
+                text = "Private",
+                modifier = Modifier.padding(top = 0.dp, start = 18.dp, end = 18.dp, bottom = 15.dp),
+                color = Grey,
+                fontStyle = FontStyle.Normal,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily.Default,
+                textAlign = TextAlign.Start,
+                style = MaterialTheme.typography.titleSmall)
+          } else {
+            isPrivateEvent.value = false
+            Text(
+                text = "Public",
+                modifier = Modifier.padding(top = 0.dp, start = 18.dp, end = 18.dp, bottom = 15.dp),
+                color = Grey,
+                fontStyle = FontStyle.Normal,
+                fontWeight = FontWeight.SemiBold,
+                fontFamily = FontFamily.Default,
+                textAlign = TextAlign.Start,
+                style = MaterialTheme.typography.titleSmall)
           }
+        }
       },
       bottomBar = {
         BottomNavigationMenu(
@@ -142,14 +140,12 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
             tabList = TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.CREATE)
       }) { innerPadding ->
-
         Column(
-            Modifier
-                .padding(innerPadding)
-                .verticalScroll(rememberScrollState()),
+            Modifier.padding(innerPadding).verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
-              //Spacer(modifier = Modifier.size((LocalConfiguration.current.screenHeightDp / 9).dp))
+              // Spacer(modifier = Modifier.size((LocalConfiguration.current.screenHeightDp /
+              // 9).dp))
 
               OutlinedTextField(
                   value = titleState.value,
@@ -164,10 +160,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                  Modifier
-                      .fillMaxWidth()
-                      .padding(start = 7.dp, end = 7.dp)
-                      .testTag("Title"))
+                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Title"))
 
               OutlinedTextField(
                   value = descriptionState.value,
@@ -182,10 +175,9 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                  Modifier
-                      .fillMaxWidth()
-                      .padding(start = 7.dp, end = 7.dp)
-                      .testTag("Description"))
+                      Modifier.fillMaxWidth()
+                          .padding(start = 7.dp, end = 7.dp)
+                          .testTag("Description"))
 
               OutlinedTextField(
                   value = locationState.value,
@@ -200,10 +192,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                  Modifier
-                      .fillMaxWidth()
-                      .padding(start = 7.dp, end = 7.dp)
-                      .testTag("Location"))
+                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Location"))
 
               OutlinedTextField(
                   value = textDate.value,
@@ -226,10 +215,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                  Modifier
-                      .fillMaxWidth()
-                      .padding(start = 7.dp, end = 7.dp)
-                      .testTag("Date"))
+                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Date"))
 
               OutlinedTextField(
                   value = priceText,
@@ -247,10 +233,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                  Modifier
-                      .fillMaxWidth()
-                      .padding(start = 7.dp, end = 7.dp)
-                      .testTag("Price"))
+                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Price"))
 
               OutlinedTextField(
                   value = url.value,
@@ -264,16 +247,11 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,
                           unfocusedBorderColor = MaterialTheme.colorScheme.onBackground),
                   modifier =
-                  Modifier
-                      .fillMaxWidth()
-                      .padding(start = 7.dp, end = 7.dp)
-                      .testTag("Link"))
+                      Modifier.fillMaxWidth().padding(start = 7.dp, end = 7.dp).testTag("Link"))
 
               if (isPrivate) {
                 Button(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(7.dp),
+                    modifier = Modifier.fillMaxWidth().padding(7.dp),
                     onClick = {
                       nav.navigateTo(
                           SECOND_LEVEL_DESTINATION.first { it.route == Route.ADD_PARTICIPANTS })
@@ -285,9 +263,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
               }
 
               Button(
-                  modifier = Modifier
-                      .fillMaxWidth()
-                      .padding(7.dp),
+                  modifier = Modifier.fillMaxWidth().padding(7.dp),
                   onClick = {
                     if (imageUri != null) {
                       imageUri = null

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -97,6 +97,43 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
 
   Scaffold(
       modifier = Modifier.testTag("CreateEvent"),
+      topBar = {
+          Column {
+              Text(
+                  text = "Create",
+                  modifier = Modifier.padding(horizontal = 15.dp, vertical = 15.dp),
+                  color = DarkCyan,
+                  fontStyle = FontStyle.Normal,
+                  fontWeight = FontWeight.SemiBold,
+                  fontFamily = FontFamily.Default,
+                  textAlign = TextAlign.Start,
+                  style = MaterialTheme.typography.headlineLarge)
+
+              if (isPrivate) {
+                  isPrivateEvent.value = true
+                  Text(
+                      text = "Private",
+                      modifier = Modifier.padding(horizontal = 18.dp),
+                      color = Grey,
+                      fontStyle = FontStyle.Normal,
+                      fontWeight = FontWeight.SemiBold,
+                      fontFamily = FontFamily.Default,
+                      textAlign = TextAlign.Start,
+                      style = MaterialTheme.typography.titleSmall)
+              } else {
+                  isPrivateEvent.value = false
+                  Text(
+                      text = "Public",
+                      modifier = Modifier.padding(horizontal = 18.dp),
+                      color = Grey,
+                      fontStyle = FontStyle.Normal,
+                      fontWeight = FontWeight.SemiBold,
+                      fontFamily = FontFamily.Default,
+                      textAlign = TextAlign.Start,
+                      style = MaterialTheme.typography.titleSmall)
+              }
+          }
+      },
       bottomBar = {
         BottomNavigationMenu(
             onTabSelect = { selectedTab ->
@@ -105,42 +142,11 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
             tabList = TOP_LEVEL_DESTINATIONS,
             selectedItem = Route.CREATE)
       }) { innerPadding ->
-        Text(
-            text = "Create",
-            modifier = Modifier.padding(horizontal = 15.dp, vertical = 15.dp),
-            color = DarkCyan,
-            fontStyle = FontStyle.Normal,
-            fontWeight = FontWeight.SemiBold,
-            fontFamily = FontFamily.Default,
-            textAlign = TextAlign.Start,
-            style = MaterialTheme.typography.headlineLarge)
-
-        if (isPrivate) {
-          isPrivateEvent.value = true
-          Text(
-              text = "Private",
-              modifier = Modifier.padding(horizontal = 18.dp, vertical = 55.dp),
-              color = Grey,
-              fontStyle = FontStyle.Normal,
-              fontWeight = FontWeight.SemiBold,
-              fontFamily = FontFamily.Default,
-              textAlign = TextAlign.Start,
-              style = MaterialTheme.typography.titleSmall)
-        } else {
-          isPrivateEvent.value = false
-          Text(
-              text = "Public",
-              modifier = Modifier.padding(horizontal = 18.dp, vertical = 55.dp),
-              color = Grey,
-              fontStyle = FontStyle.Normal,
-              fontWeight = FontWeight.SemiBold,
-              fontFamily = FontFamily.Default,
-              textAlign = TextAlign.Start,
-              style = MaterialTheme.typography.titleSmall)
-        }
 
         Column(
-            Modifier.padding(innerPadding).verticalScroll(rememberScrollState()),
+            Modifier
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
               Spacer(modifier = Modifier.size((LocalConfiguration.current.screenHeightDp / 9).dp))
@@ -263,21 +269,20 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                       .padding(start = 7.dp, end = 7.dp)
                       .testTag("Link"))
 
-            if (isPrivate) {
+              if (isPrivate) {
                 Button(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(7.dp),
                     onClick = {
-                        nav.navigateTo(SECOND_LEVEL_DESTINATION.first { it.route == Route.ADD_PARTICIPANTS })
+                      nav.navigateTo(
+                          SECOND_LEVEL_DESTINATION.first { it.route == Route.ADD_PARTICIPANTS })
                     },
                     colors = ButtonDefaults.buttonColors(containerColor = Grey),
                     shape = RoundedCornerShape(10.dp)) {
-                    Text(
-                        text = "Add Participants",
-                        color = Color.White)
-                }
-            }
+                      Text(text = "Add Participants", color = Color.White)
+                    }
+              }
 
               Button(
                   modifier = Modifier

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -149,7 +149,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                 .verticalScroll(rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center) {
-              Spacer(modifier = Modifier.size((LocalConfiguration.current.screenHeightDp / 9).dp))
+              //Spacer(modifier = Modifier.size((LocalConfiguration.current.screenHeightDp / 9).dp))
 
               OutlinedTextField(
                   value = titleState.value,

--- a/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
@@ -32,7 +32,7 @@ object Route {
   const val PUBLIC_CREATE = "Public Create"
   const val PRIVATE_CREATE = "Private Create"
   const val OTHERS_PROFILE = "Others Profile"
-    const val ADD_PARTICIPANTS = "Add Participants"
+  const val ADD_PARTICIPANTS = "Add Participants"
 }
 
 val CREATE_ITEMS =

--- a/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
@@ -32,6 +32,7 @@ object Route {
   const val PUBLIC_CREATE = "Public Create"
   const val PRIVATE_CREATE = "Private Create"
   const val OTHERS_PROFILE = "Others Profile"
+    const val ADD_PARTICIPANTS = "Add Participants"
 }
 
 val CREATE_ITEMS =
@@ -72,7 +73,11 @@ val SECOND_LEVEL_DESTINATION =
         TopLevelDestination(
             route = Route.OTHERS_PROFILE,
             icon = Icons.Default.Person,
-            textId = Route.OTHERS_PROFILE))
+            textId = Route.OTHERS_PROFILE),
+        TopLevelDestination(
+            route = Route.ADD_PARTICIPANTS,
+            icon = Icons.Default.Person,
+            textId = Route.ADD_PARTICIPANTS))
 
 class NavigationActions(val navController: NavHostController) {
   fun navigateTo(destination: TopLevelDestination, clearBackStack: Boolean = false) {


### PR DESCRIPTION
In this pull request, we added the "Add Participants" button when the user wants to create a private event.

`CreateEvent.kt`: To do so, we added a button with the Text "Add Participants" only when we want to create a private event. Moreover, now that there are a lot of elements on the screen we need the screen to be able to vertically scroll up and down, so we added that in the modifier. Furthermore, to have the texts "Create" and "Public" or "Private" at the top of the screen disappear when we scroll down, we needed to add those elements in a Column as the topBar of our Scaffold (in the previous version, the Scaffold didn't have a topBar and we modified the padding of those 3 texts so that the UI looks good.

`AddParticipants.kt`: This is where the user will be able to add people in his private event. For now the UI is not implemented as we need the logic for the invites to be done and well thought first so it just shows a text "Add Participants" for now.

`NavigationAction.kt`: We added the AddParticipants screen as a secondary level destination.

`MainActivity.kt`: We added in our NavGraph the AddParticipants screen.

`CreateEventTest`: We added a test to ensure that the "Add Participants" button is correctly displayed. 