### PR TITLE
s5 ui adjustments

### DIFF
--- a/app/src/main/java/com/github/se/gomeet/ui/authscreens/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/authscreens/LoginScreen.kt
@@ -39,6 +39,15 @@ fun LoginScreen(authViewModel: AuthViewModel, onNavToExplore: () -> Unit) {
   val signInState = authViewModel.signInState.collectAsState()
   val isError = signInState.value.signInError != null
   val context = LocalContext.current
+  val textFieldColors =
+      TextFieldDefaults.colors(
+          focusedTextColor = DarkCyan,
+          unfocusedTextColor = DarkCyan,
+          unfocusedContainerColor = Color.Transparent,
+          focusedContainerColor = Color.Transparent,
+          cursorColor = DarkCyan,
+          focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+          focusedIndicatorColor = MaterialTheme.colorScheme.tertiary)
 
   Column(
       verticalArrangement = Arrangement.Top,
@@ -79,15 +88,7 @@ fun LoginScreen(authViewModel: AuthViewModel, onNavToExplore: () -> Unit) {
             modifier = Modifier.fillMaxWidth().testTag("EmailField"),
             label = { Text("Email") },
             isError = isError,
-            colors =
-                TextFieldDefaults.colors(
-                    focusedTextColor = DarkCyan,
-                    unfocusedTextColor = DarkCyan,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedContainerColor = Color.Transparent,
-                    cursorColor = DarkCyan,
-                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
-                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
+            colors = textFieldColors)
 
         Spacer(modifier = Modifier.size(16.dp))
 
@@ -98,15 +99,7 @@ fun LoginScreen(authViewModel: AuthViewModel, onNavToExplore: () -> Unit) {
             modifier = Modifier.fillMaxWidth().testTag("LogInField"),
             label = { Text("Password") },
             isError = isError,
-            colors =
-                TextFieldDefaults.colors(
-                    focusedTextColor = DarkCyan,
-                    unfocusedTextColor = DarkCyan,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedContainerColor = Color.Transparent,
-                    cursorColor = DarkCyan,
-                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
-                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary),
+            colors = textFieldColors,
             visualTransformation = PasswordVisualTransformation())
 
         Spacer(modifier = Modifier.size(50.dp))

--- a/app/src/main/java/com/github/se/gomeet/ui/authscreens/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/authscreens/LoginScreen.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -76,7 +78,16 @@ fun LoginScreen(authViewModel: AuthViewModel, onNavToExplore: () -> Unit) {
             onValueChange = { newValue -> authViewModel.onEmailChange(newValue) },
             modifier = Modifier.fillMaxWidth().testTag("EmailField"),
             label = { Text("Email") },
-            isError = isError)
+            isError = isError,
+            colors =
+                TextFieldDefaults.colors(
+                    focusedTextColor = DarkCyan,
+                    unfocusedTextColor = DarkCyan,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent,
+                    cursorColor = DarkCyan,
+                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
 
         Spacer(modifier = Modifier.size(16.dp))
 
@@ -87,6 +98,15 @@ fun LoginScreen(authViewModel: AuthViewModel, onNavToExplore: () -> Unit) {
             modifier = Modifier.fillMaxWidth().testTag("LogInField"),
             label = { Text("Password") },
             isError = isError,
+            colors =
+                TextFieldDefaults.colors(
+                    focusedTextColor = DarkCyan,
+                    unfocusedTextColor = DarkCyan,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent,
+                    cursorColor = DarkCyan,
+                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary),
             visualTransformation = PasswordVisualTransformation())
 
         Spacer(modifier = Modifier.size(50.dp))
@@ -94,6 +114,12 @@ fun LoginScreen(authViewModel: AuthViewModel, onNavToExplore: () -> Unit) {
         Button(
             onClick = { authViewModel.signInWithEmailPassword(context) },
             modifier = Modifier.fillMaxWidth().testTag("LogInButton"),
+            colors =
+                ButtonColors(
+                    disabledContainerColor = MaterialTheme.colorScheme.primary,
+                    containerColor = DarkCyan,
+                    disabledContentColor = Color.White,
+                    contentColor = Color.White),
             enabled =
                 signInState.value.email.isNotEmpty() && signInState.value.password.isNotEmpty()) {
               Text("Log in")

--- a/app/src/main/java/com/github/se/gomeet/ui/authscreens/LoginScreen.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/authscreens/LoginScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -45,7 +46,8 @@ fun LoginScreen(authViewModel: AuthViewModel, onNavToExplore: () -> Unit) {
             painter = painterResource(id = R.drawable.gomeet_text),
             contentDescription = "GoMeet",
             modifier = Modifier.padding(top = 40.dp),
-            alignment = Alignment.Center)
+            alignment = Alignment.Center,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.tertiary))
 
         Spacer(modifier = Modifier.size(40.dp))
 

--- a/app/src/main/java/com/github/se/gomeet/ui/authscreens/RegisterScreen.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/authscreens/RegisterScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -52,7 +53,8 @@ fun RegisterScreen(
             painter = painterResource(id = R.drawable.gomeet_text),
             contentDescription = "Go Meet",
             modifier = Modifier.padding(top = 40.dp),
-            alignment = Alignment.Center)
+            alignment = Alignment.Center,
+            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.tertiary))
 
         Spacer(modifier = Modifier.size(40.dp))
 

--- a/app/src/main/java/com/github/se/gomeet/ui/authscreens/RegisterScreen.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/authscreens/RegisterScreen.kt
@@ -46,6 +46,15 @@ fun RegisterScreen(
   val signInState = authViewModel.signInState.collectAsState()
   val isError = signInState.value.registerError != null
   val context = LocalContext.current
+  val textFieldColors =
+      TextFieldDefaults.colors(
+          focusedTextColor = DarkCyan,
+          unfocusedTextColor = DarkCyan,
+          unfocusedContainerColor = Color.Transparent,
+          focusedContainerColor = Color.Transparent,
+          cursorColor = DarkCyan,
+          focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+          focusedIndicatorColor = MaterialTheme.colorScheme.tertiary)
 
   Column(
       verticalArrangement = Arrangement.Top,
@@ -85,15 +94,7 @@ fun RegisterScreen(
             label = { Text("Email") },
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
-            colors =
-                TextFieldDefaults.colors(
-                    focusedTextColor = DarkCyan,
-                    unfocusedTextColor = DarkCyan,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedContainerColor = Color.Transparent,
-                    cursorColor = DarkCyan,
-                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
-                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
+            colors = textFieldColors)
 
         Spacer(modifier = Modifier.size(16.dp))
 
@@ -104,15 +105,7 @@ fun RegisterScreen(
             singleLine = true,
             visualTransformation = PasswordVisualTransformation(),
             modifier = Modifier.fillMaxWidth(),
-            colors =
-                TextFieldDefaults.colors(
-                    focusedTextColor = DarkCyan,
-                    unfocusedTextColor = DarkCyan,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedContainerColor = Color.Transparent,
-                    cursorColor = DarkCyan,
-                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
-                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
+            colors = textFieldColors)
 
         Spacer(modifier = Modifier.size(16.dp))
 
@@ -123,15 +116,7 @@ fun RegisterScreen(
             visualTransformation = PasswordVisualTransformation(),
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
-            colors =
-                TextFieldDefaults.colors(
-                    focusedTextColor = DarkCyan,
-                    unfocusedTextColor = DarkCyan,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedContainerColor = Color.Transparent,
-                    cursorColor = DarkCyan,
-                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
-                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
+            colors = textFieldColors)
 
         Spacer(modifier = Modifier.size(50.dp))
 

--- a/app/src/main/java/com/github/se/gomeet/ui/authscreens/RegisterScreen.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/authscreens/RegisterScreen.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -82,7 +84,16 @@ fun RegisterScreen(
             onValueChange = { newValue -> authViewModel.onEmailRegisterChange(newValue) },
             label = { Text("Email") },
             singleLine = true,
-            modifier = Modifier.fillMaxWidth())
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                TextFieldDefaults.colors(
+                    focusedTextColor = DarkCyan,
+                    unfocusedTextColor = DarkCyan,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent,
+                    cursorColor = DarkCyan,
+                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
 
         Spacer(modifier = Modifier.size(16.dp))
 
@@ -92,7 +103,16 @@ fun RegisterScreen(
             label = { Text("Password") },
             singleLine = true,
             visualTransformation = PasswordVisualTransformation(),
-            modifier = Modifier.fillMaxWidth())
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                TextFieldDefaults.colors(
+                    focusedTextColor = DarkCyan,
+                    unfocusedTextColor = DarkCyan,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent,
+                    cursorColor = DarkCyan,
+                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
 
         Spacer(modifier = Modifier.size(16.dp))
 
@@ -102,13 +122,28 @@ fun RegisterScreen(
             label = { Text("Confirm Password") },
             visualTransformation = PasswordVisualTransformation(),
             singleLine = true,
-            modifier = Modifier.fillMaxWidth())
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                TextFieldDefaults.colors(
+                    focusedTextColor = DarkCyan,
+                    unfocusedTextColor = DarkCyan,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedContainerColor = Color.Transparent,
+                    cursorColor = DarkCyan,
+                    focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+                    focusedIndicatorColor = MaterialTheme.colorScheme.tertiary))
 
         Spacer(modifier = Modifier.size(50.dp))
 
         Button(
             onClick = { authViewModel.signUpWithEmailPassword(context) },
             modifier = Modifier.fillMaxWidth().testTag("register_button"),
+            colors =
+                ButtonColors(
+                    disabledContainerColor = MaterialTheme.colorScheme.primary,
+                    containerColor = DarkCyan,
+                    disabledContentColor = Color.White,
+                    contentColor = Color.White),
             enabled =
                 signInState.value.emailRegister.isNotEmpty() &&
                     signInState.value.passwordRegister.isNotEmpty() &&

--- a/app/src/main/java/com/github/se/gomeet/ui/authscreens/WelcomeScreen.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/authscreens/WelcomeScreen.kt
@@ -178,19 +178,20 @@ fun WelcomeScreenPreview() {
 
 @Composable
 fun DividerWithText() {
+  val color = MaterialTheme.colorScheme.tertiary
   Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxWidth()) {
     Canvas(modifier = Modifier.matchParentSize()) {
       val canvasWidth = size.width
       val canvasHalfHeight = size.height / 2
 
       drawLine(
-          color = Color.Black,
+          color = color,
           strokeWidth = 2f,
           start = Offset(x = 120f, y = canvasHalfHeight),
           end = Offset(x = (canvasWidth / 2) - 50f, y = canvasHalfHeight),
       )
       drawLine(
-          color = Color.Black,
+          color = color,
           strokeWidth = 2f,
           start = Offset(x = (canvasWidth / 2) + 50f, y = canvasHalfHeight),
           end = Offset(x = canvasWidth - 120, y = canvasHalfHeight),
@@ -204,7 +205,7 @@ fun DividerWithText() {
                 fontSize = 15.sp,
                 fontFamily = FontFamily(Font(R.font.roboto)),
                 fontWeight = FontWeight(700),
-                color = Color.Black,
+                color = color,
             ))
   }
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Events.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Events.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -132,7 +133,7 @@ fun Events(nav: NavigationActions, eventViewModel: EventViewModel) {
             verticalArrangement = Arrangement.Top,
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(innerPadding)) {
-              SearchBar(query, NavBarUnselected)
+              SearchBar(query, NavBarUnselected, Color.DarkGray)
               Spacer(modifier = Modifier.height(5.dp))
               Row(
                   verticalAlignment = Alignment.CenterVertically,
@@ -196,30 +197,33 @@ fun Events(nav: NavigationActions, eventViewModel: EventViewModel) {
                           Modifier.padding(10.dp).align(Alignment.Start).testTag("MyTicketsText"))
 
                   eventList.forEach { event ->
-                    val painter: Painter =
-                        if (event.images.isNotEmpty()) {
-                          rememberAsyncImagePainter(
-                              ImageRequest.Builder(LocalContext.current)
-                                  .data(data = event.images[0])
-                                  .apply(
-                                      block =
-                                          fun ImageRequest.Builder.() {
-                                            crossfade(true)
-                                            placeholder(R.drawable.gomeet_logo)
-                                          })
-                                  .build())
-                        } else {
-                          painterResource(id = R.drawable.gomeet_logo)
-                        }
+                    if (event.title.contains(query.value, ignoreCase = true)) {
+                      val painter: Painter =
+                          if (event.images.isNotEmpty()) {
+                            rememberAsyncImagePainter(
+                                ImageRequest.Builder(LocalContext.current)
+                                    .data(data = event.images[0])
+                                    .apply(
+                                        block =
+                                            fun ImageRequest.Builder.() {
+                                              crossfade(true)
+                                              placeholder(R.drawable.gomeet_logo)
+                                            })
+                                    .build())
+                          } else {
+                            painterResource(id = R.drawable.gomeet_logo)
+                          }
 
-                    EventWidget(
-                        userName = event.creator,
-                        eventName = event.title,
-                        eventDate =
-                            Date.from(event.date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
-                        eventPicture = painter,
-                        verified = false,
-                        nav = nav) // verification to be done using user details
+                      EventWidget(
+                          userName = event.creator,
+                          eventName = event.title,
+                          eventDate =
+                              Date.from(
+                                  event.date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+                          eventPicture = painter,
+                          verified = false,
+                          nav = nav) // verification to be done using user details
+                    }
                   }
                 }
 
@@ -241,29 +245,32 @@ fun Events(nav: NavigationActions, eventViewModel: EventViewModel) {
                           Modifier.padding(10.dp).align(Alignment.Start).testTag("FavouritesText"))
 
                   eventList.forEach { event ->
-                    val painter: Painter =
-                        if (event.images.isNotEmpty()) {
-                          rememberAsyncImagePainter(
-                              ImageRequest.Builder(LocalContext.current)
-                                  .data(data = event.images[0])
-                                  .apply(
-                                      block =
-                                          fun ImageRequest.Builder.() {
-                                            crossfade(true)
-                                            placeholder(R.drawable.gomeet_logo)
-                                          })
-                                  .build())
-                        } else {
-                          painterResource(id = R.drawable.gomeet_logo)
-                        }
-                    EventWidget(
-                        userName = event.creator,
-                        eventName = event.title,
-                        eventDate =
-                            Date.from(event.date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
-                        eventPicture = painter,
-                        verified = false,
-                        nav = nav)
+                    if (event.title.contains(query.value, ignoreCase = true)) {
+                      val painter: Painter =
+                          if (event.images.isNotEmpty()) {
+                            rememberAsyncImagePainter(
+                                ImageRequest.Builder(LocalContext.current)
+                                    .data(data = event.images[0])
+                                    .apply(
+                                        block =
+                                            fun ImageRequest.Builder.() {
+                                              crossfade(true)
+                                              placeholder(R.drawable.gomeet_logo)
+                                            })
+                                    .build())
+                          } else {
+                            painterResource(id = R.drawable.gomeet_logo)
+                          }
+                      EventWidget(
+                          userName = event.creator,
+                          eventName = event.title,
+                          eventDate =
+                              Date.from(
+                                  event.date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+                          eventPicture = painter,
+                          verified = false,
+                          nav = nav)
+                    }
                   }
                 }
 
@@ -284,29 +291,32 @@ fun Events(nav: NavigationActions, eventViewModel: EventViewModel) {
                           Modifier.padding(10.dp).align(Alignment.Start).testTag("MyEventsText"))
 
                   eventList.forEach { event ->
-                    val painter: Painter =
-                        if (event.images.isNotEmpty()) {
-                          rememberAsyncImagePainter(
-                              ImageRequest.Builder(LocalContext.current)
-                                  .data(data = event.images[0])
-                                  .apply(
-                                      block =
-                                          fun ImageRequest.Builder.() {
-                                            crossfade(true)
-                                            placeholder(R.drawable.gomeet_logo)
-                                          })
-                                  .build())
-                        } else {
-                          painterResource(id = R.drawable.gomeet_logo)
-                        }
-                    EventWidget(
-                        userName = event.creator,
-                        eventName = event.title,
-                        eventDate =
-                            Date.from(event.date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
-                        eventPicture = painter,
-                        verified = false,
-                        nav = nav)
+                    if (event.title.contains(query.value, ignoreCase = true)) {
+                      val painter: Painter =
+                          if (event.images.isNotEmpty()) {
+                            rememberAsyncImagePainter(
+                                ImageRequest.Builder(LocalContext.current)
+                                    .data(data = event.images[0])
+                                    .apply(
+                                        block =
+                                            fun ImageRequest.Builder.() {
+                                              crossfade(true)
+                                              placeholder(R.drawable.gomeet_logo)
+                                            })
+                                    .build())
+                          } else {
+                            painterResource(id = R.drawable.gomeet_logo)
+                          }
+                      EventWidget(
+                          userName = event.creator,
+                          eventName = event.title,
+                          eventDate =
+                              Date.from(
+                                  event.date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+                          eventPicture = painter,
+                          verified = false,
+                          nav = nav)
+                    }
                   }
                 }
               }
@@ -459,7 +469,7 @@ fun EventWidget(
 }
 
 @Composable
-fun SearchBar(query: MutableState<String>, backgroundColor: Color) {
+fun SearchBar(query: MutableState<String>, backgroundColor: Color, contentColor: Color) {
   BasicTextField(
       value = query.value,
       onValueChange = { query.value = it },
@@ -469,6 +479,7 @@ fun SearchBar(query: MutableState<String>, backgroundColor: Color) {
               .height(50.dp)
               .background(backgroundColor, RoundedCornerShape(25.dp)),
       singleLine = true,
+      cursorBrush = SolidColor(Color.White),
       decorationBox = {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -479,8 +490,8 @@ fun SearchBar(query: MutableState<String>, backgroundColor: Color) {
                     ImageVector.vectorResource(R.drawable.gomeet_icon),
                     contentDescription = null,
                     modifier = Modifier.padding(end = 20.dp),
-                    tint = Color.Black)
-                Text(text = if (query.value == "") "Search" else query.value, color = Color.Black)
+                    tint = contentColor)
+                Text(text = if (query.value == "") "Search" else query.value, color = contentColor)
               }
               Row(
                   verticalAlignment = Alignment.CenterVertically,
@@ -492,7 +503,7 @@ fun SearchBar(query: MutableState<String>, backgroundColor: Color) {
                         colors =
                             ButtonColors(
                                 containerColor = Color.Transparent,
-                                contentColor = Color.Black,
+                                contentColor = contentColor,
                                 disabledContainerColor = Color.Transparent,
                                 disabledContentColor = Color.Transparent),
                         modifier = Modifier.wrapContentSize(),
@@ -500,9 +511,9 @@ fun SearchBar(query: MutableState<String>, backgroundColor: Color) {
                       Icon(
                           ImageVector.vectorResource(R.drawable.mic_icon),
                           contentDescription = null,
-                          tint = Color.Black)
+                          tint = contentColor)
                     }
-                    Icon(Icons.Default.Search, contentDescription = null, tint = Color.Black)
+                    Icon(Icons.Default.Search, contentDescription = null, tint = contentColor)
                   }
             }
       })

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Events.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Events.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
@@ -479,7 +478,6 @@ fun SearchBar(query: MutableState<String>, backgroundColor: Color, contentColor:
               .height(50.dp)
               .background(backgroundColor, RoundedCornerShape(25.dp)),
       singleLine = true,
-      cursorBrush = SolidColor(Color.White),
       decorationBox = {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Explore.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -185,7 +186,7 @@ fun Explore(nav: NavigationActions, eventViewModel: EventViewModel) {
             CircularProgressIndicator()
           }
         }
-        SearchBar(query, Color.White)
+        SearchBar(query, MaterialTheme.colorScheme.background, MaterialTheme.colorScheme.tertiary)
       }
 }
 
@@ -238,34 +239,32 @@ fun GoogleMapView(
   }
 
   if (mapVisible) {
-    Box(Modifier.fillMaxSize()) {
-      GoogleMap(
-          modifier = modifier,
-          cameraPositionState = cameraPositionState,
-          properties = mapProperties,
-          uiSettings = uiSettings,
-          onMapLoaded = onMapLoaded,
-          onMapClick = { isButtonVisible.value = true },
-          onPOIClick = {}) {
-            val markerClick: (Marker) -> Boolean = {
-              isButtonVisible.value = false
-              false
-            }
-
-            for (i in eventStates.indices) {
-              MarkerInfoWindowContent(
-                  state = eventStates[i],
-                  title = events.value[i].title,
-                  icon =
-                      BitmapDescriptorFactory.defaultMarker(
-                          BitmapDescriptorFactory.HUE_RED), // TODO: change this
-                  onClick = markerClick,
-                  visible = events.value[i].title.contains(query.value, ignoreCase = true)) {
-                    Text(it.title!!, color = Color.Black)
-                  }
-            }
-            content()
+    GoogleMap(
+        modifier = modifier,
+        cameraPositionState = cameraPositionState,
+        properties = mapProperties,
+        uiSettings = uiSettings,
+        onMapLoaded = onMapLoaded,
+        onMapClick = { isButtonVisible.value = true },
+        onPOIClick = {}) {
+          val markerClick: (Marker) -> Boolean = {
+            isButtonVisible.value = false
+            false
           }
-    }
+
+          for (i in eventStates.indices) {
+            MarkerInfoWindowContent(
+                state = eventStates[i],
+                title = events.value[i].title,
+                icon =
+                    BitmapDescriptorFactory.defaultMarker(
+                        BitmapDescriptorFactory.HUE_RED), // TODO: change this
+                onClick = markerClick,
+                visible = events.value[i].title.contains(query.value, ignoreCase = true)) {
+                  Text(it.title!!, color = Color.Black)
+                }
+          }
+          content()
+        }
   }
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -243,6 +243,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                   placeholder = { Text("Enter a link") },
                   singleLine = true,
                   shape = RoundedCornerShape(10.dp),
+                  textStyle = TextStyle(color = MaterialTheme.colorScheme.onBackground),
                   colors =
                       TextFieldDefaults.outlinedTextFieldColors(
                           focusedBorderColor = MaterialTheme.colorScheme.onBackground,

--- a/app/src/main/java/com/github/se/gomeet/ui/theme/Theme.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/theme/Theme.kt
@@ -1,18 +1,14 @@
 package com.github.se.gomeet.ui.theme
 
 import android.app.Activity
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
@@ -52,10 +48,6 @@ fun GoMeetTheme(
 ) {
   val colorScheme =
       when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-          val context = LocalContext.current
-          if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
       }


### PR DESCRIPTION
Did some ui adjustments, mainly related to dark mode.

Search bar improvements: 
- added a parameter to set the color of the content
- changed content color from black to dark gray (for light mode)
- made the search bar in Explore dark when in dark mode

Dark mode related issues:
- fixed issues #60, #61 and #64

Fixed issue #27, GoMeetTheme should now be applied correctly.

Implemented searching in Events.

Changed the colors of the login and register screens to be more similar to the Figma version.

New version of modified screens:

![Capture d'écran 2024-04-23 195712](https://github.com/SwEnt-Project-G18/SwEntApp/assets/125990940/d05b21e1-bcb9-43aa-b8e9-b2de09cc63ce)

![Capture d'écran 2024-04-23 195825](https://github.com/SwEnt-Project-G18/SwEntApp/assets/125990940/4f34f6de-70ce-4040-8047-0048f98234d9)
![Capture d'écran 2024-04-23 195837](https://github.com/SwEnt-Project-G18/SwEntApp/assets/125990940/9ce6cbd5-f678-41c4-85af-a206e7f92c6f)
![Capture d'écran 2024-04-23 195752](https://github.com/SwEnt-Project-G18/SwEntApp/assets/125990940/dec216fc-1e60-4652-a88f-1b809e17dad8)
![Capture d'écran 2024-04-23 195806](https://github.com/SwEnt-Project-G18/SwEntApp/assets/125990940/6578b83f-4097-4d31-91e2-1e10be59f719)
![Capture d'écran 2024-04-23 195727](https://github.com/SwEnt-Project-G18/SwEntApp/assets/125990940/894e167e-a85e-4e66-949e-80a10d38618e)
