### PR TITLE
Fix Incorrect User Profile Viewing and Messaging Behavior

### DIFF
--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
@@ -71,6 +71,7 @@ import com.google.maps.android.compose.rememberMarkerState
 @Composable
 fun EventHeader(
     title: String,
+    currentUser: GoMeetUser,
     organizer: GoMeetUser,
     rating: Double,
     nav: NavigationActions,
@@ -94,7 +95,11 @@ fun EventHeader(
           Text(
               modifier =
                   Modifier.clickable {
-                        nav.navigateToScreen(Route.OTHERS_PROFILE.replace("{uid}", organizer.uid))
+                        if (organizer.uid == currentUser.uid) {
+                          nav.navigateToScreen(Route.PROFILE)
+                        } else {
+                          nav.navigateToScreen(Route.OTHERS_PROFILE.replace("{uid}", organizer.uid))
+                        }
                       }
                       .testTag("Username"),
               text = organizer.username,

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
@@ -105,6 +105,7 @@ fun MyEventInfo(
                       .verticalScroll(state = rememberScrollState())) {
                 EventHeader(
                     title = title,
+                    currentUser = currentUser.value!!,
                     organizer = organizer.value!!,
                     rating = rating,
                     nav = nav,


### PR DESCRIPTION
This pull request addresses an issue where a user could view and interact with their own profile as if it were another user's profile. This behavior allowed users to attempt to send messages to themselves, which is not intended functionality. We have resolved this issue by implementing a redirection mechanism. Now, when a user attempts to view their profile through another user's perspective, they are automatically redirected to their correct profile view. 