### PR TITLE
Firebase caching implementation

### DIFF
--- a/app/src/androidTest/java/com/github/se/gomeet/InstrTestRunner.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/InstrTestRunner.kt
@@ -3,7 +3,10 @@ package com.github.se.gomeet
 import android.os.Bundle
 import androidx.test.runner.AndroidJUnitRunner
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.firestoreSettings
 import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.firestore.memoryCacheSettings
+import com.google.firebase.firestore.persistentCacheSettings
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
 
@@ -21,9 +24,19 @@ class InstrTestRunner : AndroidJUnitRunner() {
   }
 
   private fun setupGlobalTestEnvironment() {
+    val cacheSize = 1024L * 1024L * 100L
+
     Firebase.auth.useEmulator("10.0.2.2", 9099)
     Firebase.storage.useEmulator("10.0.2.2.", 9199)
     Firebase.firestore.useEmulator("10.0.2.2", 8080)
+    Firebase.firestore.firestoreSettings = firestoreSettings {
+      setLocalCacheSettings(memoryCacheSettings {})
+      setLocalCacheSettings(
+          persistentCacheSettings {
+            // Set size to 100 MB
+            setSizeBytes(cacheSize)
+          })
+    }
   }
 
   private fun tearDownGlobalTestEnvironment() {}

--- a/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.github.se.gomeet.MainActivity
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.screens.CreateEventScreen
 import com.github.se.gomeet.screens.CreateScreen
 import com.github.se.gomeet.screens.EventsScreen
@@ -19,6 +21,7 @@ import com.github.se.gomeet.screens.WelcomeScreenScreen
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
@@ -158,7 +161,7 @@ class EndToEndTest : TestCase() {
     fun setup() {
       TimeUnit.SECONDS.sleep(3)
       // create a new user
-      userVM = UserViewModel()
+      userVM = UserViewModel(UserRepository(Firebase.firestore))
       var result = Firebase.auth.createUserWithEmailAndPassword(email, pwd)
       while (!result.isComplete) {
         TimeUnit.SECONDS.sleep(1)
@@ -172,7 +175,7 @@ class EndToEndTest : TestCase() {
       while (!result.isComplete) {
         TimeUnit.SECONDS.sleep(1)
       }
-      eventVM = EventViewModel(uid)
+      eventVM = EventViewModel(uid, EventRepository(Firebase.firestore))
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd2.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd2.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.gomeet.MainActivity
 import com.github.se.gomeet.model.event.location.Location
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.screens.EventInfoScreen
 import com.github.se.gomeet.screens.FollowersScreen
 import com.github.se.gomeet.screens.FollowingScreen
@@ -22,6 +24,7 @@ import com.github.se.gomeet.screens.WelcomeScreenScreen
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
@@ -167,7 +170,7 @@ class EndToEndTest2 : TestCase() {
     @BeforeClass
     fun setup() {
       // create two new users
-      userVM = UserViewModel()
+      userVM = UserViewModel(UserRepository(Firebase.firestore))
       var result = Firebase.auth.createUserWithEmailAndPassword(email1, pwd1)
       while (!result.isComplete) {}
       uid1 = result.result.user!!.uid
@@ -199,7 +202,7 @@ class EndToEndTest2 : TestCase() {
       result = Firebase.auth.signInWithEmailAndPassword(email1, pwd1)
       while (!result.isComplete) {}
 
-      eventVM = EventViewModel(Firebase.auth.currentUser!!.uid)
+      eventVM = EventViewModel(Firebase.auth.currentUser!!.uid, EventRepository(Firebase.firestore))
       runBlocking {
         eventVM.createEvent(
             "title",
@@ -224,7 +227,7 @@ class EndToEndTest2 : TestCase() {
       TimeUnit.SECONDS.sleep(2)
 
       // the second user is used to log in and perform the tests
-      eventVM = EventViewModel(uid2)
+      eventVM = EventViewModel(uid2, EventRepository(Firebase.firestore))
     }
 
     @AfterClass

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/authscreens/RegisterScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/authscreens/RegisterScreenTest.kt
@@ -15,10 +15,12 @@ import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.gomeet.R
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.AuthViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
@@ -47,7 +49,7 @@ class RegisterScreenTest {
   @Test
   fun testRegisterScreen() = runTest {
     authViewModel = AuthViewModel()
-    userViewModel = UserViewModel()
+    userViewModel = UserViewModel(UserRepository(Firebase.firestore))
 
     rule.setContent {
       val client =

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/ExploreTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/ExploreTest.kt
@@ -39,7 +39,9 @@ class ExploreTest {
 
     rule.setContent {
       navController = rememberNavController()
-      Explore(nav = NavigationActions(navController), eventViewModel = EventViewModel(null, EventRepository(Firebase.firestore)))
+      Explore(
+          nav = NavigationActions(navController),
+          eventViewModel = EventViewModel(null, EventRepository(Firebase.firestore)))
     }
 
     rule.waitUntil(timeoutMillis = 10000) { rule.onNodeWithTag("Map").isDisplayed() }

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/ExploreTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/ExploreTest.kt
@@ -11,10 +11,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
@@ -36,7 +39,7 @@ class ExploreTest {
 
     rule.setContent {
       navController = rememberNavController()
-      Explore(nav = NavigationActions(navController), eventViewModel = EventViewModel())
+      Explore(nav = NavigationActions(navController), eventViewModel = EventViewModel(null, EventRepository(Firebase.firestore)))
     }
 
     rule.waitUntil(timeoutMillis = 10000) { rule.onNodeWithTag("Map").isDisplayed() }
@@ -60,7 +63,7 @@ class ExploreTest {
     fun setup() {
       TimeUnit.SECONDS.sleep(3)
       // create a new user
-      userViewModel = UserViewModel()
+      userViewModel = UserViewModel(UserRepository(Firebase.firestore))
       var result = Firebase.auth.createUserWithEmailAndPassword(email, pwd)
       while (!result.isComplete) {
         TimeUnit.SECONDS.sleep(1)
@@ -84,7 +87,7 @@ class ExploreTest {
         TimeUnit.SECONDS.sleep(1)
       }
 
-      eventViewModel = EventViewModel(uid)
+      eventViewModel = EventViewModel(uid, EventRepository(Firebase.firestore))
     }
 
     @AfterClass

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/TrendsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/TrendsTest.kt
@@ -7,9 +7,13 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,8 +32,8 @@ class TrendsTest {
       Trends(
           currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
           nav = NavigationActions(rememberNavController()),
-          userViewModel = UserViewModel(),
-          eventViewModel = EventViewModel())
+          userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
+          eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
     }
 
     rule.onAllNodesWithText("Trends").apply {

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/TrendsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/TrendsTest.kt
@@ -33,7 +33,8 @@ class TrendsTest {
           currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
           nav = NavigationActions(rememberNavController()),
           userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
-          eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
+          eventViewModel =
+              EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
     }
 
     rule.onAllNodesWithText("Trends").apply {

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/create/CreateEventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/create/CreateEventTest.kt
@@ -11,9 +11,12 @@ import androidx.compose.ui.test.performTextInput
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gomeet.model.repository.EventRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.google.android.gms.maps.MapsInitializer
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import java.time.LocalDate
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -104,7 +107,7 @@ class CreateEventTest {
     @JvmStatic
     @BeforeClass
     fun setup() {
-      eventViewModel = EventViewModel(uid)
+      eventViewModel = EventViewModel(uid, EventRepository(Firebase.firestore))
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/events/EventInfoTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/events/EventInfoTest.kt
@@ -5,10 +5,12 @@ import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.navigation.compose.rememberNavController
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
@@ -66,7 +68,7 @@ class EventInfoTest {
     private val eventTime = "00:00"
     private val eventDescription = "Event Description"
     private val eventLocation = LatLng(0.0, 0.0)
-    private val userViewModel = UserViewModel()
+    private val userViewModel = UserViewModel(UserRepository(Firebase.firestore))
     private val eventRating = 4.5
     private lateinit var currentUserId: String
 

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/events/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/events/EventsTest.kt
@@ -4,9 +4,13 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.compose.rememberNavController
 import com.github.se.gomeet.model.event.location.Location
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import java.time.LocalDate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -24,8 +28,8 @@ class EventsTest {
       Events(
           currentUser = "test",
           nav = NavigationActions(rememberNavController()),
-          userViewModel = UserViewModel(),
-          eventViewModel = EventViewModel())
+          userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
+          eventViewModel = EventViewModel("test", EventRepository(Firebase.firestore)))
     }
 
     composeTestRule.onNode(hasText("My events")).assertIsDisplayed()
@@ -43,8 +47,8 @@ class EventsTest {
       Events(
           currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
           nav = NavigationActions(rememberNavController()),
-          userViewModel = UserViewModel(),
-          eventViewModel = EventViewModel())
+          userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
+          eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
     }
 
     composeTestRule.onNodeWithText("JoinedEvents").performClick()
@@ -55,7 +59,7 @@ class EventsTest {
   @Test
   fun eventsScreen_AsyncBehavior() {
     // Test asynchronous behavior of fetching events
-    val eventViewModel = EventViewModel()
+    val eventViewModel = EventViewModel(null, EventRepository(Firebase.firestore))
     runBlocking(Dispatchers.IO) {
       // Add a mock event to the view model
       eventViewModel.createEvent(
@@ -72,7 +76,7 @@ class EventsTest {
           tags = emptyList(),
           images = emptyList(),
           imageUri = null,
-          userViewModel = UserViewModel(),
+          userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
           uid = "")
     }
 
@@ -80,8 +84,8 @@ class EventsTest {
       Events(
           currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
           nav = NavigationActions(rememberNavController()),
-          userViewModel = UserViewModel(),
-          eventViewModel = EventViewModel())
+          userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
+          eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/events/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/events/EventsTest.kt
@@ -48,7 +48,8 @@ class EventsTest {
           currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
           nav = NavigationActions(rememberNavController()),
           userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
-          eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
+          eventViewModel =
+              EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
     }
 
     composeTestRule.onNodeWithText("JoinedEvents").performClick()
@@ -85,7 +86,8 @@ class EventsTest {
           currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
           nav = NavigationActions(rememberNavController()),
           userViewModel = UserViewModel(UserRepository(Firebase.firestore)),
-          eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
+          eventViewModel =
+              EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", EventRepository(Firebase.firestore)))
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/EditProfileTest.kt
@@ -6,9 +6,11 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.navigation.compose.rememberNavController
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import java.util.concurrent.TimeUnit
 import org.junit.AfterClass
@@ -36,7 +38,7 @@ class EditProfileTest {
   }
 
   companion object {
-    private val userViewModel = UserViewModel()
+    private val userViewModel = UserViewModel(UserRepository(Firebase.firestore))
     private lateinit var currentUserId: String
 
     private val usr = "u@t.com"

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfileTest.kt
@@ -9,9 +9,13 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,7 +30,7 @@ class OthersProfileTest {
 
     rule.setContent {
       navController = rememberNavController()
-      OthersProfile(NavigationActions(navController), "", UserViewModel(), EventViewModel())
+      OthersProfile(NavigationActions(navController), "", UserViewModel(UserRepository(Firebase.firestore)), EventViewModel(null, EventRepository(Firebase.firestore)))
     }
 
     rule.onNodeWithTag("TopBar").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfileTest.kt
@@ -30,7 +30,11 @@ class OthersProfileTest {
 
     rule.setContent {
       navController = rememberNavController()
-      OthersProfile(NavigationActions(navController), "", UserViewModel(UserRepository(Firebase.firestore)), EventViewModel(null, EventRepository(Firebase.firestore)))
+      OthersProfile(
+          NavigationActions(navController),
+          "",
+          UserViewModel(UserRepository(Firebase.firestore)),
+          EventViewModel(null, EventRepository(Firebase.firestore)))
     }
 
     rule.onNodeWithTag("TopBar").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/ProfileTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/ProfileTest.kt
@@ -5,9 +5,13 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.navigation.compose.rememberNavController
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import org.junit.Rule
 import org.junit.Test
 
@@ -21,8 +25,8 @@ class ProfileTest {
       Profile(
           NavigationActions(rememberNavController()),
           userId = "1234",
-          UserViewModel(),
-          EventViewModel())
+          UserViewModel(UserRepository(Firebase.firestore)),
+          EventViewModel("1234", EventRepository(Firebase.firestore)))
     }
 
     composeTestRule.onNodeWithText("My Profile").assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/navigation/NavigationTest.kt
@@ -32,8 +32,8 @@ class NavigationTest {
 
     composeTestRule.setContent {
       val nav = rememberNavController()
-        val userRepository = UserRepository(Firebase.firestore)
-        val eventRepository = EventRepository(Firebase.firestore)
+      val userRepository = UserRepository(Firebase.firestore)
+      val eventRepository = EventRepository(Firebase.firestore)
       NavHost(navController = nav, startDestination = Route.EVENTS) {
         composable(TOP_LEVEL_DESTINATIONS[0].route) {
           Explore(nav = NavigationActions(nav), EventViewModel(null, eventRepository))
@@ -54,7 +54,11 @@ class NavigationTest {
         }
         composable(TOP_LEVEL_DESTINATIONS[3].route) { Create(NavigationActions(nav)) }
         composable(TOP_LEVEL_DESTINATIONS[4].route) {
-          Profile(NavigationActions(nav), userId = "1234", UserViewModel(userRepository), EventViewModel("1234", eventRepository))
+          Profile(
+              NavigationActions(nav),
+              userId = "1234",
+              UserViewModel(userRepository),
+              EventViewModel("1234", eventRepository))
         }
         // Add more destinations as needed
       }
@@ -73,8 +77,8 @@ class NavigationTest {
 
     composeTestRule.setContent {
       val nav = rememberNavController()
-        val userRepository = UserRepository(Firebase.firestore)
-        val eventRepository = EventRepository(Firebase.firestore)
+      val userRepository = UserRepository(Firebase.firestore)
+      val eventRepository = EventRepository(Firebase.firestore)
       NavHost(navController = nav, startDestination = TOP_LEVEL_DESTINATIONS[0].route) {
         composable(TOP_LEVEL_DESTINATIONS[0].route) {
           Explore(nav = NavigationActions(nav), EventViewModel(null, eventRepository))
@@ -95,7 +99,11 @@ class NavigationTest {
         }
         composable(TOP_LEVEL_DESTINATIONS[3].route) { Create(NavigationActions(nav)) }
         composable(TOP_LEVEL_DESTINATIONS[4].route) {
-          Profile(NavigationActions(nav), userId = "TestUser", UserViewModel(userRepository), EventViewModel("TestUser", eventRepository))
+          Profile(
+              NavigationActions(nav),
+              userId = "TestUser",
+              UserViewModel(userRepository),
+              EventViewModel("TestUser", eventRepository))
         }
       }
 

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/navigation/NavigationTest.kt
@@ -6,6 +6,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.mainscreens.Explore
 import com.github.se.gomeet.ui.mainscreens.Trends
 import com.github.se.gomeet.ui.mainscreens.create.Create
@@ -13,6 +15,8 @@ import com.github.se.gomeet.ui.mainscreens.events.Events
 import com.github.se.gomeet.ui.mainscreens.profile.Profile
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -28,27 +32,29 @@ class NavigationTest {
 
     composeTestRule.setContent {
       val nav = rememberNavController()
+        val userRepository = UserRepository(Firebase.firestore)
+        val eventRepository = EventRepository(Firebase.firestore)
       NavHost(navController = nav, startDestination = Route.EVENTS) {
         composable(TOP_LEVEL_DESTINATIONS[0].route) {
-          Explore(nav = NavigationActions(nav), EventViewModel())
+          Explore(nav = NavigationActions(nav), EventViewModel(null, eventRepository))
         }
         composable(TOP_LEVEL_DESTINATIONS[1].route) {
           Events(
               currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
               nav = NavigationActions(rememberNavController()),
-              userViewModel = UserViewModel(),
-              eventViewModel = EventViewModel())
+              userViewModel = UserViewModel(userRepository),
+              eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", eventRepository))
         }
         composable(TOP_LEVEL_DESTINATIONS[2].route) {
           Trends(
               currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
               nav = NavigationActions(rememberNavController()),
-              userViewModel = UserViewModel(),
-              eventViewModel = EventViewModel())
+              userViewModel = UserViewModel(userRepository),
+              eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", eventRepository))
         }
         composable(TOP_LEVEL_DESTINATIONS[3].route) { Create(NavigationActions(nav)) }
         composable(TOP_LEVEL_DESTINATIONS[4].route) {
-          Profile(NavigationActions(nav), userId = "1234", UserViewModel(), EventViewModel())
+          Profile(NavigationActions(nav), userId = "1234", UserViewModel(userRepository), EventViewModel("1234", eventRepository))
         }
         // Add more destinations as needed
       }
@@ -67,27 +73,29 @@ class NavigationTest {
 
     composeTestRule.setContent {
       val nav = rememberNavController()
+        val userRepository = UserRepository(Firebase.firestore)
+        val eventRepository = EventRepository(Firebase.firestore)
       NavHost(navController = nav, startDestination = TOP_LEVEL_DESTINATIONS[0].route) {
         composable(TOP_LEVEL_DESTINATIONS[0].route) {
-          Explore(nav = NavigationActions(nav), EventViewModel())
+          Explore(nav = NavigationActions(nav), EventViewModel(null, eventRepository))
         }
         composable(TOP_LEVEL_DESTINATIONS[1].route) {
           Events(
               currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
               nav = NavigationActions(rememberNavController()),
-              userViewModel = UserViewModel(),
-              eventViewModel = EventViewModel())
+              userViewModel = UserViewModel(userRepository),
+              eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", eventRepository))
         }
         composable(TOP_LEVEL_DESTINATIONS[2].route) {
           Trends(
               currentUser = "NEEGn5cbkJZDXaezeGdfd2D4u6b2",
               nav = NavigationActions(rememberNavController()),
-              userViewModel = UserViewModel(),
-              eventViewModel = EventViewModel())
+              userViewModel = UserViewModel(userRepository),
+              eventViewModel = EventViewModel("NEEGn5cbkJZDXaezeGdfd2D4u6b2", eventRepository))
         }
         composable(TOP_LEVEL_DESTINATIONS[3].route) { Create(NavigationActions(nav)) }
         composable(TOP_LEVEL_DESTINATIONS[4].route) {
-          Profile(NavigationActions(nav), userId = "TestUser", UserViewModel(), EventViewModel())
+          Profile(NavigationActions(nav), userId = "TestUser", UserViewModel(userRepository), EventViewModel("TestUser", eventRepository))
         }
       }
 

--- a/app/src/androidTest/java/com/github/se/gomeet/viewmodel/EventViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/viewmodel/EventViewModelTest.kt
@@ -3,6 +3,10 @@ package com.github.se.gomeet.viewmodel
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.gomeet.model.event.Event
 import com.github.se.gomeet.model.event.location.Location
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import java.time.LocalDate
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -17,7 +21,7 @@ class EventViewModelTest {
 
   @Test
   fun test() = runTest {
-    val eventViewModel = EventViewModel(uid)
+    val eventViewModel = EventViewModel(uid, EventRepository(Firebase.firestore))
 
     // test getAllEvents and createEvent
     runBlocking {
@@ -35,7 +39,7 @@ class EventViewModelTest {
           emptyList(),
           emptyList(),
           null,
-          UserViewModel(),
+          UserViewModel(UserRepository(Firebase.firestore)),
           uid)
     }
 

--- a/app/src/androidTest/java/com/github/se/gomeet/viewmodel/UserViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/viewmodel/UserViewModelTest.kt
@@ -1,7 +1,10 @@
 package com.github.se.gomeet.viewmodel
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.runTest
 import org.junit.BeforeClass
@@ -71,7 +74,7 @@ class UserViewModelTest {
     @BeforeClass
     @JvmStatic
     fun setup() {
-      userViewModel = UserViewModel()
+      userViewModel = UserViewModel(UserRepository(Firebase.firestore))
     }
   }
 }

--- a/app/src/main/java/com/github/se/gomeet/MainActivity.kt
+++ b/app/src/main/java/com/github/se/gomeet/MainActivity.kt
@@ -75,33 +75,35 @@ import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
 /** The main activity of the application. */
 class MainActivity : ComponentActivity() {
 
-    private lateinit var db: FirebaseFirestore
+  private lateinit var db: FirebaseFirestore
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
     MapsInitializer.initialize(this)
 
-      val cacheSize = 1024L * 1024L * 100L
+    val cacheSize = 1024L * 1024L * 100L
 
-      // Initialize Firestore settings
-      val firestoreSettings = FirebaseFirestoreSettings.Builder()
-          .setLocalCacheSettings(memoryCacheSettings {})
-          .setLocalCacheSettings(
-              persistentCacheSettings {
+    // Initialize Firestore settings
+    val firestoreSettings =
+        FirebaseFirestoreSettings.Builder()
+            .setLocalCacheSettings(memoryCacheSettings {})
+            .setLocalCacheSettings(
+                persistentCacheSettings {
                   // Set size to 100 MB
                   setSizeBytes(cacheSize)
-              })
-          .build()
+                })
+            .build()
 
-      // Get Firestore instance and apply settings
-      db = Firebase.firestore
-      db.firestoreSettings = firestoreSettings
+    // Get Firestore instance and apply settings
+    db = Firebase.firestore
+    db.firestoreSettings = firestoreSettings
 
-      // Enable indexing for persistent cache
-      db.persistentCacheIndexManager?.apply {
-          // Indexing is disabled by default
-          enableIndexAutoCreation()
-      } ?: println("indexManager is null")
+    // Enable indexing for persistent cache
+    db.persistentCacheIndexManager?.apply {
+      // Indexing is disabled by default
+      enableIndexAutoCreation()
+    } ?: println("indexManager is null")
 
     // 1 - Set up the OfflinePlugin for offline storage
     val offlinePluginFactory = StreamOfflinePluginFactory(appContext = applicationContext)
@@ -124,9 +126,9 @@ class MainActivity : ComponentActivity() {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
           val userIdState = remember { mutableStateOf("") }
           val nav = rememberNavController()
-            val eventRepository = EventRepository(db)
-            val userRepository = UserRepository(db)
-            val invitesRepository = InvitesRepository(db)
+          val eventRepository = EventRepository(db)
+          val userRepository = UserRepository(db)
+          val invitesRepository = InvitesRepository(db)
           val authViewModel = AuthViewModel()
           val eventViewModel = EventViewModel(null, eventRepository)
           val userViewModel = UserViewModel(userRepository)
@@ -211,10 +213,14 @@ class MainActivity : ComponentActivity() {
                       eventViewModel)
                 }
             composable(Route.PRIVATE_CREATE) {
-              CreateEvent(navAction, EventViewModel(Firebase.auth.currentUser!!.uid, eventRepository), true)
+              CreateEvent(
+                  navAction, EventViewModel(Firebase.auth.currentUser!!.uid, eventRepository), true)
             }
             composable(Route.PUBLIC_CREATE) {
-              CreateEvent(navAction, EventViewModel(Firebase.auth.currentUser!!.uid, eventRepository), false)
+              CreateEvent(
+                  navAction,
+                  EventViewModel(Firebase.auth.currentUser!!.uid, eventRepository),
+                  false)
             }
 
             composable(

--- a/app/src/main/java/com/github/se/gomeet/MainActivity.kt
+++ b/app/src/main/java/com/github/se/gomeet/MainActivity.kt
@@ -19,6 +19,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.InvitesRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.authscreens.LoginScreen
 import com.github.se.gomeet.ui.authscreens.RegisterScreen
 import com.github.se.gomeet.ui.authscreens.WelcomeScreen
@@ -50,6 +53,12 @@ import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.android.gms.maps.MapsInitializer
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreSettings
+import com.google.firebase.firestore.firestoreSettings
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.firestore.memoryCacheSettings
+import com.google.firebase.firestore.persistentCacheSettings
 import com.google.firebase.ktx.Firebase
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
@@ -64,10 +73,34 @@ import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
 
 /** The main activity of the application. */
 class MainActivity : ComponentActivity() {
+
+    private lateinit var db: FirebaseFirestore
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
     MapsInitializer.initialize(this)
+
+      val cacheSize = 1024L * 1024L * 100L
+
+      // Initialize Firestore settings
+      val firestoreSettings = FirebaseFirestoreSettings.Builder()
+          .setLocalCacheSettings(memoryCacheSettings {})
+          .setLocalCacheSettings(
+              persistentCacheSettings {
+                  // Set size to 100 MB
+                  setSizeBytes(cacheSize)
+              })
+          .build()
+
+      // Get Firestore instance and apply settings
+      db = Firebase.firestore
+      db.firestoreSettings = firestoreSettings
+
+      // Enable indexing for persistent cache
+      db.persistentCacheIndexManager?.apply {
+          // Indexing is disabled by default
+          enableIndexAutoCreation()
+      } ?: println("indexManager is null")
 
     // 1 - Set up the OfflinePlugin for offline storage
     val offlinePluginFactory = StreamOfflinePluginFactory(appContext = applicationContext)
@@ -90,10 +123,13 @@ class MainActivity : ComponentActivity() {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
           val userIdState = remember { mutableStateOf("") }
           val nav = rememberNavController()
+            val eventRepository = EventRepository(db)
+            val userRepository = UserRepository(db)
+            val invitesRepository = InvitesRepository(db)
           val authViewModel = AuthViewModel()
-          val eventViewModel = EventViewModel()
-          val userViewModel = UserViewModel()
-          val eventInviteViewModel = EventInviteViewModel()
+          val eventViewModel = EventViewModel(null, eventRepository)
+          val userViewModel = UserViewModel(userRepository)
+          val eventInviteViewModel = EventInviteViewModel(invitesRepository)
           val navAction = NavigationActions(nav)
           NavHost(navController = nav, startDestination = Route.WELCOME) {
             composable(Route.WELCOME) {
@@ -150,10 +186,10 @@ class MainActivity : ComponentActivity() {
             composable(Route.EXPLORE) { Explore(navAction, eventViewModel) }
             composable(Route.EVENTS) {
               userIdState.value = Firebase.auth.currentUser!!.uid
-              Events(userIdState.value, navAction, UserViewModel(), eventViewModel)
+              Events(userIdState.value, navAction, UserViewModel(userRepository), eventViewModel)
             }
             composable(Route.TRENDS) {
-              Trends(userIdState.value, navAction, UserViewModel(), eventViewModel)
+              Trends(userIdState.value, navAction, UserViewModel(userRepository), eventViewModel)
             }
             composable(Route.CREATE) {
               userIdState.value = Firebase.auth.currentUser!!.uid
@@ -177,10 +213,10 @@ class MainActivity : ComponentActivity() {
                       eventViewModel)
                 }
             composable(Route.PRIVATE_CREATE) {
-              CreateEvent(navAction, EventViewModel(Firebase.auth.currentUser!!.uid), true)
+              CreateEvent(navAction, EventViewModel(Firebase.auth.currentUser!!.uid, eventRepository), true)
             }
             composable(Route.PUBLIC_CREATE) {
-              CreateEvent(navAction, EventViewModel(Firebase.auth.currentUser!!.uid), false)
+              CreateEvent(navAction, EventViewModel(Firebase.auth.currentUser!!.uid, eventRepository), false)
             }
 
             composable(

--- a/app/src/main/java/com/github/se/gomeet/model/repository/EventRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/EventRepository.kt
@@ -6,11 +6,6 @@ import com.github.se.gomeet.model.event.location.Location
 import com.google.firebase.firestore.DocumentChange
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.MetadataChanges
-import com.google.firebase.firestore.firestoreSettings
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.firestore.memoryCacheSettings
-import com.google.firebase.firestore.persistentCacheSettings
-import com.google.firebase.ktx.Firebase
 import java.time.LocalDate
 
 /**

--- a/app/src/main/java/com/github/se/gomeet/model/repository/EventRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/EventRepository.kt
@@ -25,24 +25,6 @@ class EventRepository(private val db: FirebaseFirestore) {
 
   /** This function initializes the repository by starting to listen for events */
   init {
-    val settings = firestoreSettings {
-      // Use memory cache
-      setLocalCacheSettings(memoryCacheSettings {})
-      // Use persistent disk cache (default)
-      setLocalCacheSettings(
-          persistentCacheSettings {
-            // Set size to 100 MB
-            setSizeBytes(1024 * 1024 * 100)
-          })
-    }
-    db.firestoreSettings = settings
-
-    // Enable indexing for persistent cache
-    Firebase.firestore.persistentCacheIndexManager?.apply {
-      // Indexing is disabled by default
-      enableIndexAutoCreation()
-    } ?: println("indexManager is null")
-
     startListeningForEvents()
   }
 

--- a/app/src/main/java/com/github/se/gomeet/model/repository/InvitesRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/InvitesRepository.kt
@@ -7,11 +7,6 @@ import com.github.se.gomeet.model.event.UserInvitedToEvents
 import com.google.firebase.firestore.DocumentChange
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.MetadataChanges
-import com.google.firebase.firestore.firestoreSettings
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.firestore.memoryCacheSettings
-import com.google.firebase.firestore.persistentCacheSettings
-import com.google.firebase.ktx.Firebase
 
 /**
  * This class represents the repository for the invites. A repository is a class that communicates

--- a/app/src/main/java/com/github/se/gomeet/model/repository/InvitesRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/InvitesRepository.kt
@@ -24,24 +24,6 @@ class InvitesRepository(private val db: FirebaseFirestore) {
 
   /** This function initializes the repository by starting to listen for invites */
   init {
-    val settings = firestoreSettings {
-      // Use memory cache
-      setLocalCacheSettings(memoryCacheSettings {})
-      // Use persistent disk cache (default)
-      setLocalCacheSettings(
-          persistentCacheSettings {
-            // Set size to 100 MB
-            setSizeBytes(1024 * 1024 * 100)
-          })
-    }
-    db.firestoreSettings = settings
-
-    // Enable indexing for persistent cache
-    Firebase.firestore.persistentCacheIndexManager?.apply {
-      // Indexing is disabled by default
-      enableIndexAutoCreation()
-    } ?: println("indexManager is null")
-
     startListeningForInvites()
   }
 

--- a/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
@@ -4,8 +4,10 @@ import android.util.Log
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.firestoreSettings
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.firestore.memoryCacheSettings
 import com.google.firebase.firestore.persistentCacheSettings
+import com.google.firebase.ktx.Firebase
 
 /**
  * Class that connects to the Firebase Firestore database to get, add, update and remove users.
@@ -21,18 +23,26 @@ class UserRepository(private val db: FirebaseFirestore) {
     private const val USERS_COLLECTION = "users"
   }
 
-    init {
-        val settings = firestoreSettings {
-            // Use memory cache
-            setLocalCacheSettings(memoryCacheSettings {})
-            // Use persistent disk cache (default)
-            setLocalCacheSettings(persistentCacheSettings {
-                // Set size to 100 MB
-                setSizeBytes(1024 * 1024 * 100)
-            })
-        }
-        db.firestoreSettings = settings
+  init {
+    val settings = firestoreSettings {
+      // Use memory cache
+      setLocalCacheSettings(memoryCacheSettings {})
+      // Use persistent disk cache (default)
+      setLocalCacheSettings(
+          persistentCacheSettings {
+            // Set size to 100 MB
+            setSizeBytes(1024 * 1024 * 100)
+          })
     }
+
+    // Enable indexing for persistent cache
+    Firebase.firestore.persistentCacheIndexManager?.apply {
+      // Indexing is disabled by default
+      enableIndexAutoCreation()
+    } ?: println("indexManager is null")
+
+    db.firestoreSettings = settings
+  }
 
   /**
    * This function retrieves all users from the database

--- a/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
@@ -23,50 +23,6 @@ class UserRepository(private val db: FirebaseFirestore) {
     private const val USERS_COLLECTION = "users"
   }
 
-  init {
-    val settings = firestoreSettings {
-      // Use memory cache
-      setLocalCacheSettings(memoryCacheSettings {})
-      // Use persistent disk cache (default)
-      setLocalCacheSettings(
-          persistentCacheSettings {
-            // Set size to 100 MB
-            setSizeBytes(1024 * 1024 * 100)
-          })
-    }
-
-    // Enable indexing for persistent cache
-    Firebase.firestore.persistentCacheIndexManager?.apply {
-      // Indexing is disabled by default
-      enableIndexAutoCreation()
-    } ?: println("indexManager is null")
-
-    db.firestoreSettings = settings
-  }
-
-  /**
-   * This function retrieves all users from the database
-   *
-   * @param callback The callback function to be called when the users are retrieved
-   */
-  fun getAllUsers(callback: (List<GoMeetUser>) -> Unit) {
-    db.collection(USERS_COLLECTION)
-        .get()
-        .addOnSuccessListener { querySnapshot ->
-          val userList = mutableListOf<GoMeetUser>()
-          for (document in querySnapshot.documents) {
-            val user = document.data?.fromMap(document.id)
-            if (user != null) {
-              userList.add(user)
-            }
-          }
-        }
-        .addOnFailureListener { exception ->
-          Log.d(TAG, "Error getting documents: ", exception)
-          callback(emptyList())
-        }
-  }
-
   /**
    * Get the user with its id.
    *

--- a/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
@@ -3,6 +3,9 @@ package com.github.se.gomeet.model.repository
 import android.util.Log
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.firestoreSettings
+import com.google.firebase.firestore.memoryCacheSettings
+import com.google.firebase.firestore.persistentCacheSettings
 
 /**
  * Class that connects to the Firebase Firestore database to get, add, update and remove users.
@@ -17,6 +20,19 @@ class UserRepository(private val db: FirebaseFirestore) {
     private const val TAG = "FirebaseConnection"
     private const val USERS_COLLECTION = "users"
   }
+
+    init {
+        val settings = firestoreSettings {
+            // Use memory cache
+            setLocalCacheSettings(memoryCacheSettings {})
+            // Use persistent disk cache (default)
+            setLocalCacheSettings(persistentCacheSettings {
+                // Set size to 100 MB
+                setSizeBytes(1024 * 1024 * 100)
+            })
+        }
+        db.firestoreSettings = settings
+    }
 
   /**
    * This function retrieves all users from the database

--- a/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/repository/UserRepository.kt
@@ -3,11 +3,6 @@ package com.github.se.gomeet.model.repository
 import android.util.Log
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.firestoreSettings
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.firestore.memoryCacheSettings
-import com.google.firebase.firestore.persistentCacheSettings
-import com.google.firebase.ktx.Firebase
 
 /**
  * Class that connects to the Firebase Firestore database to get, add, update and remove users.

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -90,7 +90,7 @@ private const val NUMBER_OF_SUGGESTIONS = 3
 fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivate: Boolean) {
 
   val eventRepository = EventRepository(Firebase.firestore)
-    val userRepository = UserRepository(Firebase.firestore)
+  val userRepository = UserRepository(Firebase.firestore)
   val uid = eventRepository.getNewId()
   val titleState = remember { mutableStateOf("") }
   val descriptionState = remember { mutableStateOf("") }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.window.Dialog
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.location.Location
 import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.ui.navigation.Route
@@ -88,8 +89,9 @@ private const val NUMBER_OF_SUGGESTIONS = 3
 @Composable
 fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivate: Boolean) {
 
-  val db = EventRepository(Firebase.firestore)
-  val uid = db.getNewId()
+  val eventRepository = EventRepository(Firebase.firestore)
+    val userRepository = UserRepository(Firebase.firestore)
+  val uid = eventRepository.getNewId()
   val titleState = remember { mutableStateOf("") }
   val descriptionState = remember { mutableStateOf("") }
   val locationState = remember { mutableStateOf("") }
@@ -342,7 +344,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                                 listOf(),
                                 listOf(),
                                 imageUri,
-                                UserViewModel(),
+                                UserViewModel(userRepository),
                                 uid)
 
                             nav.goBack()
@@ -363,7 +365,7 @@ fun CreateEvent(nav: NavigationActions, eventViewModel: EventViewModel, isPrivat
                             listOf(),
                             listOf(),
                             imageUri,
-                            UserViewModel(),
+                            UserViewModel(userRepository),
                             uid)
 
                         nav.goBack()

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/Events.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/Events.kt
@@ -69,9 +69,9 @@ import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.Event
+import com.github.se.gomeet.model.event.location.Location
 import com.github.se.gomeet.model.repository.EventRepository
 import com.github.se.gomeet.model.repository.UserRepository
-import com.github.se.gomeet.model.event.location.Location
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.mainscreens.LoadingText
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/Events.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/Events.kt
@@ -495,7 +495,9 @@ fun EventWidget(
                         horizontalArrangement = Arrangement.Center) {
                           var username by remember { mutableStateOf<String?>("Loading...") }
                           LaunchedEffect(userName) {
-                            username = UserViewModel(UserRepository(Firebase.firestore)).getUsername(userName)
+                            username =
+                                UserViewModel(UserRepository(Firebase.firestore))
+                                    .getUsername(userName)
                           }
 
                           username?.let {
@@ -624,7 +626,11 @@ fun GoMeetSearchBar(
 @Composable
 @Preview
 fun EventPreview() {
-  Events("", nav = NavigationActions(rememberNavController()), UserViewModel(UserRepository(Firebase.firestore)), EventViewModel("", EventRepository(Firebase.firestore)))
+  Events(
+      "",
+      nav = NavigationActions(rememberNavController()),
+      UserViewModel(UserRepository(Firebase.firestore)),
+      EventViewModel("", EventRepository(Firebase.firestore)))
   /*EventWidget(
   "EPFL Chess Club",
   "Chess Tournament",

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/Events.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/Events.kt
@@ -68,6 +68,8 @@ import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.Event
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.mainscreens.LoadingText
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
@@ -79,6 +81,8 @@ import com.github.se.gomeet.ui.theme.NavBarUnselected
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.android.gms.maps.model.LatLng
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import java.text.SimpleDateFormat
 import java.time.ZoneId
 import java.util.Calendar
@@ -484,7 +488,7 @@ fun EventWidget(
                         horizontalArrangement = Arrangement.Center) {
                           var username by remember { mutableStateOf<String?>("Loading...") }
                           LaunchedEffect(userName) {
-                            username = UserViewModel().getUsername(userName)
+                            username = UserViewModel(UserRepository(Firebase.firestore)).getUsername(userName)
                           }
 
                           username?.let {
@@ -606,7 +610,7 @@ fun GoMeetSearchBar(query: MutableState<String>, backgroundColor: Color, content
 @Composable
 @Preview
 fun EventPreview() {
-  Events("", nav = NavigationActions(rememberNavController()), UserViewModel(), EventViewModel())
+  Events("", nav = NavigationActions(rememberNavController()), UserViewModel(UserRepository(Firebase.firestore)), EventViewModel("", EventRepository(Firebase.firestore)))
   /*EventWidget(
   "EPFL Chess Club",
   "Chess Tournament",

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.github.se.gomeet.R
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.mainscreens.LoadingText
 import com.github.se.gomeet.ui.navigation.NavigationActions
@@ -39,6 +41,7 @@ import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.launch
 
@@ -120,7 +123,7 @@ fun MyEventInfo(
                 Spacer(modifier = Modifier.height(20.dp))
 
                 var imageUrl by remember { mutableStateOf<String?>(null) }
-                LaunchedEffect(eventId) { imageUrl = EventViewModel().getEventImageUrl(eventId) }
+                LaunchedEffect(eventId) { imageUrl = EventViewModel(userViewModel.getCurrentUser()!!.uid,eventRepository = EventRepository(Firebase.firestore)).getEventImageUrl(eventId) }
                 EventImage(imageUrl = imageUrl)
                 Spacer(modifier = Modifier.height(20.dp))
                 EventDescription(text = description)
@@ -143,5 +146,5 @@ fun PreviewEventInfo() {
       time = "00:00",
       description = "Event Description",
       loc = LatLng(0.0, 0.0),
-      userViewModel = UserViewModel())
+      userViewModel = UserViewModel(userRepository = UserRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
@@ -123,7 +123,13 @@ fun MyEventInfo(
                 Spacer(modifier = Modifier.height(20.dp))
 
                 var imageUrl by remember { mutableStateOf<String?>(null) }
-                LaunchedEffect(eventId) { imageUrl = EventViewModel(userViewModel.getCurrentUser()!!.uid,eventRepository = EventRepository(Firebase.firestore)).getEventImageUrl(eventId) }
+                LaunchedEffect(eventId) {
+                  imageUrl =
+                      EventViewModel(
+                              organizer.value!!.uid,
+                              eventRepository = EventRepository(Firebase.firestore))
+                          .getEventImageUrl(eventId)
+                }
                 EventImage(imageUrl = imageUrl)
                 Spacer(modifier = Modifier.height(20.dp))
                 EventDescription(text = description)

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/EditProfile.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/EditProfile.kt
@@ -52,8 +52,10 @@ import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 
 @Composable
-fun EditProfile(nav: NavigationActions, userViewModel: UserViewModel = UserViewModel(UserRepository(
-    Firebase.firestore))) {
+fun EditProfile(
+    nav: NavigationActions,
+    userViewModel: UserViewModel = UserViewModel(UserRepository(Firebase.firestore))
+) {
   val currentUser = remember { mutableStateOf<GoMeetUser?>(null) }
   val firstName = remember { mutableStateOf("") }
   val lastName = remember { mutableStateOf("") }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/EditProfile.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/EditProfile.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.github.se.gomeet.R
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
 import com.github.se.gomeet.ui.navigation.NavigationActions
@@ -47,9 +48,12 @@ import com.github.se.gomeet.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.github.se.gomeet.ui.theme.DarkCyan
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.auth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 
 @Composable
-fun EditProfile(nav: NavigationActions, userViewModel: UserViewModel = UserViewModel()) {
+fun EditProfile(nav: NavigationActions, userViewModel: UserViewModel = UserViewModel(UserRepository(
+    Firebase.firestore))) {
   val currentUser = remember { mutableStateOf<GoMeetUser?>(null) }
   val firstName = remember { mutableStateOf("") }
   val lastName = remember { mutableStateOf("") }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Followers.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Followers.kt
@@ -156,5 +156,8 @@ fun Followers(nav: NavigationActions, uid: String, userViewModel: UserViewModel)
 @Preview
 @Composable
 fun FollowersPreview() {
-  Followers(NavigationActions(rememberNavController()), "", UserViewModel(UserRepository(Firebase.firestore)))
+  Followers(
+      NavigationActions(rememberNavController()),
+      "",
+      UserViewModel(UserRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Followers.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Followers.kt
@@ -41,11 +41,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.github.se.gomeet.R
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.ui.navigation.Route
 import com.github.se.gomeet.ui.theme.DarkCyan
 import com.github.se.gomeet.viewmodel.UserViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.launch
 
 private var currentUser: GoMeetUser? = null
@@ -153,5 +156,5 @@ fun Followers(nav: NavigationActions, uid: String, userViewModel: UserViewModel)
 @Preview
 @Composable
 fun FollowersPreview() {
-  Followers(NavigationActions(rememberNavController()), "", UserViewModel())
+  Followers(NavigationActions(rememberNavController()), "", UserViewModel(UserRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Following.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Following.kt
@@ -198,5 +198,8 @@ fun Following(
 @Preview
 @Composable
 fun FollowingPreview() {
-  Following(NavigationActions(rememberNavController()), "", UserViewModel(UserRepository(Firebase.firestore)))
+  Following(
+      NavigationActions(rememberNavController()),
+      "",
+      UserViewModel(UserRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Following.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Following.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.github.se.gomeet.R
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.ui.navigation.Route
@@ -50,6 +51,7 @@ import com.github.se.gomeet.ui.theme.DarkCyan
 import com.github.se.gomeet.ui.theme.LightGray
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.launch
 
@@ -196,5 +198,5 @@ fun Following(
 @Preview
 @Composable
 fun FollowingPreview() {
-  Following(NavigationActions(rememberNavController()), "", UserViewModel())
+  Following(NavigationActions(rememberNavController()), "", UserViewModel(UserRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfile.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfile.kt
@@ -470,5 +470,8 @@ fun MoreActionsButton() {
 @Composable
 fun OthersProfilePreview() {
   OthersProfile(
-      nav = NavigationActions(rememberNavController()), "", UserViewModel(UserRepository(Firebase.firestore)), EventViewModel(null, EventRepository(Firebase.firestore)))
+      nav = NavigationActions(rememberNavController()),
+      "",
+      UserViewModel(UserRepository(Firebase.firestore)),
+      EventViewModel(null, EventRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfile.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/OthersProfile.kt
@@ -63,6 +63,8 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.rememberNavController
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.Event
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.mainscreens.LoadingText
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
@@ -74,6 +76,7 @@ import com.github.se.gomeet.ui.theme.NavBarUnselected
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.launch
 
@@ -456,5 +459,5 @@ fun MoreActionsButton() {
 @Composable
 fun OthersProfilePreview() {
   OthersProfile(
-      nav = NavigationActions(rememberNavController()), "", UserViewModel(), EventViewModel())
+      nav = NavigationActions(rememberNavController()), "", UserViewModel(UserRepository(Firebase.firestore)), EventViewModel(null, EventRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Profile.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Profile.kt
@@ -422,6 +422,8 @@ fun Profile(
 @Composable
 fun ProfilePreview() {
   Profile(
-      nav = NavigationActions(rememberNavController()), "John", UserViewModel(UserRepository(
-          Firebase.firestore)), EventViewModel("John", EventRepository(Firebase.firestore)))
+      nav = NavigationActions(rememberNavController()),
+      "John",
+      UserViewModel(UserRepository(Firebase.firestore)),
+      EventViewModel("John", EventRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Profile.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/Profile.kt
@@ -57,6 +57,8 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.rememberNavController
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.Event
+import com.github.se.gomeet.model.repository.EventRepository
+import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.github.se.gomeet.ui.mainscreens.LoadingText
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
@@ -70,6 +72,8 @@ import com.github.se.gomeet.ui.theme.LightGray
 import com.github.se.gomeet.ui.theme.NavBarUnselected
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.launch
 
 /**
@@ -415,5 +419,6 @@ fun Profile(
 @Composable
 fun ProfilePreview() {
   Profile(
-      nav = NavigationActions(rememberNavController()), "John", UserViewModel(), EventViewModel())
+      nav = NavigationActions(rememberNavController()), "John", UserViewModel(UserRepository(
+          Firebase.firestore)), EventViewModel("John", EventRepository(Firebase.firestore)))
 }

--- a/app/src/main/java/com/github/se/gomeet/viewmodel/EventInviteViewModel.kt
+++ b/app/src/main/java/com/github/se/gomeet/viewmodel/EventInviteViewModel.kt
@@ -3,18 +3,15 @@ package com.github.se.gomeet.viewmodel
 import com.github.se.gomeet.model.event.EventInviteUsers
 import com.github.se.gomeet.model.event.InviteStatus
 import com.github.se.gomeet.model.repository.InvitesRepository
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.CompletableDeferred
 
-// _db argument to be able to pass a mock FirebaseFirestore instance for testing
 /**
  * ViewModel for event invitation logic. The viewModel is responsible for handling the logic that
  * comes from the UI and the repository.
  */
-class EventInviteViewModel {
+class EventInviteViewModel(invitesRepository: InvitesRepository) {
 
-  private val repository = InvitesRepository(Firebase.firestore)
+  private val repository = invitesRepository
 
   /**
    * Get the users invited to an event.

--- a/app/src/main/java/com/github/se/gomeet/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/github/se/gomeet/viewmodel/EventViewModel.kt
@@ -45,8 +45,8 @@ import org.json.JSONArray
  *
  * @param creatorId the id of the creator of the event
  */
-class EventViewModel(private val creatorId: String? = null) : ViewModel() {
-  private val db = EventRepository(Firebase.firestore)
+class EventViewModel(private val creatorId: String? = null, eventRepository: EventRepository) : ViewModel() {
+  private val repository = eventRepository
   private val _bitmapDescriptors = mutableStateMapOf<String, BitmapDescriptor>()
   val bitmapDescriptors: MutableMap<String, BitmapDescriptor> = _bitmapDescriptors
 
@@ -144,7 +144,7 @@ class EventViewModel(private val creatorId: String? = null) : ViewModel() {
   suspend fun getEvent(uid: String): Event? {
     return try {
       val event = CompletableDeferred<Event?>()
-      db.getEvent(uid) { t -> event.complete(t) }
+      repository.getEvent(uid) { t -> event.complete(t) }
       event.await()
     } catch (e: Exception) {
       null
@@ -200,7 +200,7 @@ class EventViewModel(private val creatorId: String? = null) : ViewModel() {
   suspend fun getAllEvents(): List<Event>? {
     return try {
       val event = CompletableDeferred<List<Event>?>()
-      db.getAllEvents { t -> event.complete(t) }
+      repository.getAllEvents { t -> event.complete(t) }
       event.await()
     } catch (e: Exception) {
       null
@@ -264,7 +264,7 @@ class EventViewModel(private val creatorId: String? = null) : ViewModel() {
                 tags,
                 updatedImages)
 
-        db.addEvent(event)
+        repository.addEvent(event)
         joinEvent(event, creatorId)
         userViewModel.joinEvent(event.uid, creatorId)
       } catch (e: Exception) {
@@ -279,7 +279,7 @@ class EventViewModel(private val creatorId: String? = null) : ViewModel() {
    * @param event the event to edit
    */
   fun editEvent(event: Event) {
-    db.updateEvent(event)
+    repository.updateEvent(event)
   }
 
   /**
@@ -288,11 +288,11 @@ class EventViewModel(private val creatorId: String? = null) : ViewModel() {
    * @param uid the UID of the event to remove
    */
   fun removeEvent(uid: String) {
-    db.removeEvent(uid)
+    repository.removeEvent(uid)
   }
 
   fun joinEvent(event: Event, userId: String) {
-    db.updateEvent(event.copy(participants = event.participants.plus(userId)))
+    repository.updateEvent(event.copy(participants = event.participants.plus(userId)))
   }
 
   /**

--- a/app/src/main/java/com/github/se/gomeet/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/github/se/gomeet/viewmodel/EventViewModel.kt
@@ -17,7 +17,6 @@ import com.github.se.gomeet.model.repository.EventRepository
 import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage
@@ -45,7 +44,8 @@ import org.json.JSONArray
  *
  * @param creatorId the id of the creator of the event
  */
-class EventViewModel(private val creatorId: String? = null, eventRepository: EventRepository) : ViewModel() {
+class EventViewModel(private val creatorId: String? = null, eventRepository: EventRepository) :
+    ViewModel() {
   private val repository = eventRepository
   private val _bitmapDescriptors = mutableStateMapOf<String, BitmapDescriptor>()
   val bitmapDescriptors: MutableMap<String, BitmapDescriptor> = _bitmapDescriptors

--- a/app/src/main/java/com/github/se/gomeet/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/gomeet/viewmodel/UserViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.ViewModel
 import com.github.se.gomeet.model.repository.UserRepository
 import com.github.se.gomeet.model.user.GoMeetUser
 import com.google.firebase.auth.ktx.auth
-import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/com/github/se/gomeet/viewmodel/UserViewModel.kt
+++ b/app/src/main/java/com/github/se/gomeet/viewmodel/UserViewModel.kt
@@ -18,9 +18,9 @@ import kotlinx.coroutines.launch
  * ViewModel for the user. The viewModel is responsible for handling the logic that comes from the
  * UI and the repository.
  */
-class UserViewModel : ViewModel() {
+class UserViewModel(userRepository: UserRepository) : ViewModel() {
   private val currentUser = mutableStateOf<GoMeetUser?>(null)
-  private val userRepository = UserRepository(Firebase.firestore)
+  private val repository = userRepository
 
   /**
    * Create a new user if the user is new.
@@ -61,24 +61,12 @@ class UserViewModel : ViewModel() {
                   myEvents = emptyList(),
                   myFavorites = emptyList())
           currentUser.value = user
-          userRepository.addUser(user)
+          repository.addUser(user)
         } catch (e: Exception) {
           Log.w(ContentValues.TAG, "Error adding user", e)
         }
       }
     }
-  }
-
-  suspend fun getFollowers(uid: String): List<GoMeetUser> {
-    val followers = mutableListOf<GoMeetUser>()
-    userRepository.getAllUsers { users ->
-      for (user in users) {
-        if (user.uid != uid && user.following.contains(uid)) {
-          followers.add(user)
-        }
-      }
-    }
-    return followers
   }
 
   /**
@@ -91,7 +79,7 @@ class UserViewModel : ViewModel() {
     return try {
       Log.d("UID IS", "User id is $uid")
       val event = CompletableDeferred<GoMeetUser?>()
-      userRepository.getUser(uid) { t -> event.complete(t) }
+      repository.getUser(uid) { t -> event.complete(t) }
       event.await()
     } catch (e: Exception) {
       null
@@ -109,7 +97,7 @@ class UserViewModel : ViewModel() {
    * @param user the user to edit
    */
   fun editUser(user: GoMeetUser) {
-    userRepository.updateUser(user)
+    repository.updateUser(user)
   }
 
   /**
@@ -118,7 +106,7 @@ class UserViewModel : ViewModel() {
    * @param uid the user id
    */
   fun deleteUser(uid: String) {
-    userRepository.removeUser(uid)
+    repository.removeUser(uid)
   }
 
   /**


### PR DESCRIPTION
This PR introduces the implementation of caching the data of the app in a local cache so that the user can still have access to the data when he is offline if this data was fetched in the cache previously before going offline. 

This is a key feature for the application since there can always be network issues in the daily life, especially depending in which country we live in, so it is important that the user can still have access to data when being offline for a moment or for a long time.

To do so, we added `Firestore` settings in the `MainActivity.kt` to ensure that modifications in the settings of our `Firestore` instance are made before it is used anywhere in our app. We enable the cache with a size of 100 MB as it is the default cache size and should be enough for our app for now, but we can modify its size later if we see that it is not enough. We also added `offline query indexes` as the tutorial suggests to add this feature for better performance when the user is offline for a long time.

Finally, note that we needed to modify also the `Firestore` instance for our tests since we use `Firebase Emulator` for our tests.