### PR TITLE
Edit Event Screen implementation

### DIFF
--- a/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
+++ b/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
@@ -128,7 +128,7 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
   val eventViewModel = remember { mutableStateOf(EventViewModel(null)) }
   val userViewModel = UserViewModel()
 
-  return NavHost(navController = nav, startDestination = Route.WELCOME) {
+  NavHost(navController = nav, startDestination = Route.WELCOME) {
     composable(Route.WELCOME) {
       WelcomeScreen(
           onNavToLogin = { NavigationActions(nav).navigateTo(LOGIN_ITEMS[1]) },
@@ -377,7 +377,19 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
         arguments = listOf(navArgument("eventId") { type = NavType.StringType })) { entry ->
           val eventId = entry.arguments?.getString("eventId") ?: ""
 
-          EditEvent(nav = navAction, eventViewModel = eventViewModel.value, eventId = eventId)
+          EditEvent(nav = navAction, eventViewModel = eventViewModel.value, eventId = eventId) {
+              updatedEvent ->
+            // Navigate to the updated event info
+            navAction.navigateToEventInfo(
+                eventId = updatedEvent.eventID,
+                title = updatedEvent.title,
+                date = updatedEvent.date.toString(),
+                time = updatedEvent.time.toString(),
+                organizer = updatedEvent.creator,
+                rating = 0.0,
+                description = updatedEvent.description,
+                loc = LatLng(updatedEvent.location.latitude, updatedEvent.location.longitude))
+          }
         }
   }
 }

--- a/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
+++ b/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
@@ -133,13 +133,8 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
       WelcomeScreen(
           onNavToLogin = { NavigationActions(nav).navigateTo(LOGIN_ITEMS[1]) },
           onNavToRegister = { NavigationActions(nav).navigateTo(LOGIN_ITEMS[2]) },
-          onSignInSuccess = {
-                  userId: String,
-                  _: String,
-                  _: String,
-                  _: String,
-                  _: String,
-                  _: String ->
+          onSignInSuccess = { userId: String, _: String, _: String, _: String, _: String, _: String
+            ->
             val currentUser = Firebase.auth.currentUser
             if (currentUser != null) {
               val uid = currentUser.uid
@@ -377,13 +372,13 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
           }
         }
     composable(route = Route.ADD_FRIEND) { AddFriend(navAction, userViewModel) }
-      composable(
-          route = Route.EDIT_EVENT,
-          arguments = listOf(navArgument("eventId") { type = NavType.StringType })) { entry ->
+    composable(
+        route = Route.EDIT_EVENT,
+        arguments = listOf(navArgument("eventId") { type = NavType.StringType })) { entry ->
           val eventId = entry.arguments?.getString("eventId") ?: ""
 
           EditEvent(nav = navAction, eventViewModel = eventViewModel.value, eventId = eventId)
-      }
+        }
   }
 }
 

--- a/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
+++ b/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
@@ -385,7 +385,7 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
             navAction.navigateToEventInfo(
                 eventId = updatedEvent.eventID,
                 title = updatedEvent.title,
-                date = getEventDateString( updatedEvent.date),
+                date = getEventDateString(updatedEvent.date),
                 time = getEventTimeString(updatedEvent.time),
                 organizer = updatedEvent.creator,
                 rating = 0.0,

--- a/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
+++ b/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
@@ -21,6 +21,7 @@ import com.github.se.gomeet.ui.mainscreens.Trends
 import com.github.se.gomeet.ui.mainscreens.create.Create
 import com.github.se.gomeet.ui.mainscreens.create.CreateEvent
 import com.github.se.gomeet.ui.mainscreens.events.AddParticipants
+import com.github.se.gomeet.ui.mainscreens.events.EditEvent
 import com.github.se.gomeet.ui.mainscreens.events.Events
 import com.github.se.gomeet.ui.mainscreens.events.MyEventInfo
 import com.github.se.gomeet.ui.mainscreens.events.manageinvites.ManageInvites
@@ -115,7 +116,6 @@ fun initChatClient(applicationContext: Context): ChatClient {
  * Set up the navigation for the app.
  *
  * @param nav The NavHostController.
- * @param db The Firestore database.
  * @param client The chat client.
  * @param applicationContext The application text.
  */
@@ -125,7 +125,7 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
   val userIdState = remember { mutableStateOf("") }
   val clientInitialisationState by client.clientState.initializationState.collectAsState()
   val authViewModel = AuthViewModel()
-  var eventViewModel = remember { mutableStateOf(EventViewModel(null)) }
+  val eventViewModel = remember { mutableStateOf(EventViewModel(null)) }
   val userViewModel = UserViewModel()
 
   return NavHost(navController = nav, startDestination = Route.WELCOME) {
@@ -134,12 +134,12 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
           onNavToLogin = { NavigationActions(nav).navigateTo(LOGIN_ITEMS[1]) },
           onNavToRegister = { NavigationActions(nav).navigateTo(LOGIN_ITEMS[2]) },
           onSignInSuccess = {
-              userId: String,
-              username: String,
-              email: String,
-              firstName: String,
-              lastName: String,
-              phoneNumber: String ->
+                  userId: String,
+                  _: String,
+                  _: String,
+                  _: String,
+                  _: String,
+                  _: String ->
             val currentUser = Firebase.auth.currentUser
             if (currentUser != null) {
               val uid = currentUser.uid
@@ -377,6 +377,13 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
           }
         }
     composable(route = Route.ADD_FRIEND) { AddFriend(navAction, userViewModel) }
+      composable(
+          route = Route.EDIT_EVENT,
+          arguments = listOf(navArgument("eventId") { type = NavType.StringType })) { entry ->
+          val eventId = entry.arguments?.getString("eventId") ?: ""
+
+          EditEvent(nav = navAction, eventViewModel = eventViewModel.value, eventId = eventId)
+      }
   }
 }
 

--- a/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
+++ b/app/src/main/java/com/github/se/gomeet/InitFunctions.kt
@@ -14,6 +14,8 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.github.se.gomeet.model.event.getEventDateString
+import com.github.se.gomeet.model.event.getEventTimeString
 import com.github.se.gomeet.ui.authscreens.LoginScreen
 import com.github.se.gomeet.ui.authscreens.WelcomeScreen
 import com.github.se.gomeet.ui.authscreens.register.RegisterScreen
@@ -383,8 +385,8 @@ fun InitNavigation(nav: NavHostController, client: ChatClient, applicationContex
             navAction.navigateToEventInfo(
                 eventId = updatedEvent.eventID,
                 title = updatedEvent.title,
-                date = updatedEvent.date.toString(),
-                time = updatedEvent.time.toString(),
+                date = getEventDateString( updatedEvent.date),
+                time = getEventTimeString(updatedEvent.time),
                 organizer = updatedEvent.creator,
                 rating = 0.0,
                 description = updatedEvent.description,

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
@@ -16,10 +16,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -82,7 +80,7 @@ fun EditEvent(
 ) {
   val context = LocalContext.current
   val coroutineScope = rememberCoroutineScope()
-    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+  val screenHeight = LocalConfiguration.current.screenHeightDp.dp
 
   var event by remember { mutableStateOf<Event?>(null) }
   var profilePictureUrl by remember { mutableStateOf<String?>(null) }
@@ -222,16 +220,16 @@ fun EditEvent(
                       contentDescription = "Event picture",
                       modifier =
                           Modifier.padding(start = 15.dp, end = 15.dp, top = 30.dp, bottom = 15.dp)
-                              .width(101.dp)
-                              .height(101.dp)
+                              .fillMaxWidth()
+                              .height(200.dp)
                               .clickable { imagePickerLauncher.launch("image/*") }
-                              .clip(CircleShape)
+                              .clip(RoundedCornerShape(12.dp))
                               .background(color = MaterialTheme.colorScheme.background)
                               .align(Alignment.CenterHorizontally)
                               .testTag("Event Picture"),
                       contentScale = ContentScale.Crop)
 
-                Spacer(modifier = Modifier.height(screenHeight / 80))
+                  Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   TextField(
                       value = titleState.value,
@@ -241,7 +239,7 @@ fun EditEvent(
                       modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
 
-                Spacer(modifier = Modifier.height(screenHeight / 80))
+                  Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   TextField(
                       value = descriptionState.value,
@@ -251,11 +249,11 @@ fun EditEvent(
                       modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
 
-                Spacer(modifier = Modifier.height(screenHeight / 80))
+                  Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   LocationField(selectedLocation, locationState, eventViewModel)
 
-                Spacer(modifier = Modifier.height(screenHeight / 30))
+                  Spacer(modifier = Modifier.height(screenHeight / 30))
 
                   DateTimePicker(pickedTime = pickedTime, pickedDate = pickedDate)
 
@@ -270,7 +268,7 @@ fun EditEvent(
                       modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
 
-                Spacer(modifier = Modifier.height(screenHeight / 80))
+                  Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   TextField(
                       value = url.value,
@@ -280,7 +278,7 @@ fun EditEvent(
                       modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
 
-                Spacer(modifier = Modifier.height(screenHeight / 80))
+                  Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   Row(
                       modifier = Modifier.fillMaxWidth().padding(start = 15.dp, top = 10.dp),

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import coil.compose.rememberAsyncImagePainter
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.TagsSelector
 import com.github.se.gomeet.model.event.Event
@@ -80,10 +81,12 @@ fun EditEvent(
     val coroutineScope = rememberCoroutineScope()
 
     var event by remember { mutableStateOf<Event?>(null) }
+    var profilePictureUrl by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(eventId) {
         eventViewModel.getEvent(eventId)?.let {
             event = it
+            profilePictureUrl = it.images.firstOrNull()
         }
     }
 
@@ -194,7 +197,13 @@ fun EditEvent(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         Image(
-                            painter = painterResource(id = R.drawable.gomeet_logo),
+                            painter = if (imageBitmap != null) {
+                                androidx.compose.ui.graphics.painter.BitmapPainter(imageBitmap!!)
+                            } else if (!profilePictureUrl.isNullOrEmpty()) {
+                                rememberAsyncImagePainter(profilePictureUrl)
+                            } else {
+                                painterResource(id = R.drawable.gomeet_logo)
+                            },
                             contentDescription = "Event picture",
                             modifier = Modifier.padding(start = 15.dp, end = 15.dp, top = 30.dp, bottom = 15.dp)
                                 .width(101.dp)

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
@@ -73,7 +73,12 @@ import java.io.InputStream
 import kotlinx.coroutines.launch
 
 @Composable
-fun EditEvent(nav: NavigationActions, eventViewModel: EventViewModel, eventId: String) {
+fun EditEvent(
+    nav: NavigationActions,
+    eventViewModel: EventViewModel,
+    eventId: String,
+    refreshEvent: (Event) -> Unit
+) {
   val context = LocalContext.current
   val coroutineScope = rememberCoroutineScope()
 
@@ -180,7 +185,7 @@ fun EditEvent(nav: NavigationActions, eventViewModel: EventViewModel, eventId: S
                                 updatedEvent
                               }
                           eventViewModel.editEvent(finalEvent)
-                          nav.goBack()
+                          refreshEvent(finalEvent)
                         }
                       }
                     })

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
@@ -62,6 +62,7 @@ import com.github.se.gomeet.model.TagsSelector
 import com.github.se.gomeet.model.event.Event
 import com.github.se.gomeet.model.event.location.Location
 import com.github.se.gomeet.ui.mainscreens.DateTimePicker
+import com.github.se.gomeet.ui.mainscreens.LoadingText
 import com.github.se.gomeet.ui.mainscreens.create.LocationField
 import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
 import com.github.se.gomeet.ui.navigation.NavigationActions
@@ -149,32 +150,41 @@ fun EditEvent(
                     Text(
                         text = "Done",
                         style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
-                        modifier = Modifier.padding(end = 15.dp).clickable {
-                            if (titleState.value.isNotEmpty() && descriptionState.value.isNotEmpty() && locationState.value.isNotEmpty() && priceText.isNotEmpty() && url.value.isNotEmpty()) {
-                                val updatedEvent = event!!.copy(
-                                    title = titleState.value,
-                                    description = descriptionState.value,
-                                    location = selectedLocation.value!!,
-                                    date = pickedDate.value,
-                                    time = pickedTime.value,
-                                    price = price,
-                                    url = url.value,
-                                    tags = tags.value
-                                )
+                        modifier = Modifier
+                            .padding(end = 15.dp)
+                            .clickable {
+                                if (titleState.value.isNotEmpty() && descriptionState.value.isNotEmpty() && locationState.value.isNotEmpty() && priceText.isNotEmpty() && url.value.isNotEmpty()) {
+                                    val updatedEvent = event!!.copy(
+                                        title = titleState.value,
+                                        description = descriptionState.value,
+                                        location = selectedLocation.value!!,
+                                        date = pickedDate.value,
+                                        time = pickedTime.value,
+                                        price = price,
+                                        url = url.value,
+                                        tags = tags.value
+                                    )
 
-                                coroutineScope.launch {
-                                    // Upload image and update event
-                                    val finalEvent = if (imageUri != null) {
-                                        val imageUrl = eventViewModel.uploadImageAndGetUrl(imageUri!!)
-                                        updatedEvent.copy(images = listOf(imageUrl))
-                                    } else {
-                                        updatedEvent
+                                    coroutineScope.launch {
+                                        // Upload image and update event
+                                        val finalEvent = if (imageUri != null) {
+                                            val imageUrl =
+                                                eventViewModel.uploadImageAndGetUrl(imageUri!!)
+                                            val updatedImages = event!!.images.toMutableList()
+                                            if (updatedImages.isNotEmpty()) {
+                                                updatedImages[0] = imageUrl
+                                            } else {
+                                                updatedImages.add(imageUrl)
+                                            }
+                                            updatedEvent.copy(images = updatedImages)
+                                        } else {
+                                            updatedEvent
+                                        }
+                                        eventViewModel.editEvent(finalEvent)
+                                        nav.goBack()
                                     }
-                                    eventViewModel.editEvent(finalEvent)
-                                    nav.goBack()
                                 }
                             }
-                        }
                     )
                 }
             },
@@ -190,7 +200,8 @@ fun EditEvent(
             content = { innerPadding ->
                 Box(modifier = Modifier.padding(innerPadding)) {
                     Column(
-                        modifier = Modifier.padding(start = 15.dp, end = 15.dp)
+                        modifier = Modifier
+                            .padding(start = 15.dp, end = 15.dp)
                             .verticalScroll(rememberScrollState(0))
                             .fillMaxSize(),
                         verticalArrangement = Arrangement.Top,
@@ -205,7 +216,8 @@ fun EditEvent(
                                 painterResource(id = R.drawable.gomeet_logo)
                             },
                             contentDescription = "Event picture",
-                            modifier = Modifier.padding(start = 15.dp, end = 15.dp, top = 30.dp, bottom = 15.dp)
+                            modifier = Modifier
+                                .padding(start = 15.dp, end = 15.dp, top = 30.dp, bottom = 15.dp)
                                 .width(101.dp)
                                 .height(101.dp)
                                 .clickable { imagePickerLauncher.launch("image/*") }
@@ -268,7 +280,9 @@ fun EditEvent(
                         Spacer(modifier = Modifier.size(16.dp))
 
                         Row(
-                            modifier = Modifier.fillMaxWidth().padding(top = 15.dp, bottom = 10.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 15.dp, bottom = 10.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
@@ -283,7 +297,8 @@ fun EditEvent(
                             Icon(
                                 Icons.AutoMirrored.Filled.KeyboardArrowRight,
                                 null,
-                                modifier = Modifier.clickable { showPopup.value = true }
+                                modifier = Modifier
+                                    .clickable { showPopup.value = true }
                                     .testTag("EditTagsButton")
                             )
                         }
@@ -303,7 +318,6 @@ fun EditEvent(
             }
         )
     } else {
-        // Display loading or error state
-        Text("Loading event details...")
+        LoadingText()
     }
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
@@ -1,0 +1,293 @@
+package com.github.se.gomeet.ui.mainscreens.events
+
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.Popup
+import com.github.se.gomeet.R
+import com.github.se.gomeet.model.TagsSelector
+import com.github.se.gomeet.model.event.Event
+import com.github.se.gomeet.model.event.location.Location
+import com.github.se.gomeet.ui.mainscreens.DateTimePicker
+import com.github.se.gomeet.ui.mainscreens.create.LocationField
+import com.github.se.gomeet.ui.navigation.BottomNavigationMenu
+import com.github.se.gomeet.ui.navigation.NavigationActions
+import com.github.se.gomeet.ui.navigation.Route
+import com.github.se.gomeet.ui.navigation.TOP_LEVEL_DESTINATIONS
+import com.github.se.gomeet.viewmodel.EventViewModel
+import java.io.InputStream
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlinx.coroutines.launch
+
+@Composable
+fun EditEvent(
+    nav: NavigationActions,
+    eventViewModel: EventViewModel,
+    eventId: String
+) {
+    val context = LocalContext.current
+
+    var event by remember { mutableStateOf<Event?>(null) }
+
+    LaunchedEffect(eventId) {
+        eventViewModel.getEvent(eventId)?.let {
+            event = it
+        }
+    }
+
+    if (event != null) {
+        val titleState = remember { mutableStateOf(event!!.title) }
+        val descriptionState = remember { mutableStateOf(event!!.description) }
+        val locationState = remember { mutableStateOf(event!!.location.name) }
+        var price by remember { mutableDoubleStateOf(event!!.price) }
+        var priceText by remember { mutableStateOf(event!!.price.toString()) }
+        val url = remember { mutableStateOf(event!!.url) }
+
+        val pickedTime = remember { mutableStateOf(event!!.time) }
+        val pickedDate = remember { mutableStateOf(event!!.date) }
+
+        val selectedLocation: MutableState<Location?> = remember { mutableStateOf(event!!.location) }
+        val tags = remember { mutableStateOf(event!!.tags) }
+        val showPopup = remember { mutableStateOf(false) }
+
+        var imageUri by remember { mutableStateOf<Uri?>(null) }
+        var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+
+        val imagePickerLauncher =
+            rememberLauncherForActivityResult(contract = ActivityResultContracts.GetContent()) { uri: Uri? ->
+                imageUri = uri
+                uri?.let { uriNonNull ->
+                    val inputStream: InputStream? =
+                        try {
+                            context.contentResolver.openInputStream(uriNonNull)
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                            null
+                        }
+                    inputStream?.let {
+                        val bitmap = BitmapFactory.decodeStream(it)
+                        imageBitmap = bitmap.asImageBitmap()
+                    }
+                }
+            }
+
+        val textFieldColors =
+            TextFieldDefaults.colors(
+                focusedTextColor = MaterialTheme.colorScheme.onBackground,
+                unfocusedTextColor = MaterialTheme.colorScheme.onBackground,
+                unfocusedContainerColor = Color.Transparent,
+                focusedContainerColor = Color.Transparent,
+                cursorColor = MaterialTheme.colorScheme.outlineVariant,
+                focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+                unfocusedLabelColor = MaterialTheme.colorScheme.tertiary,
+                focusedIndicatorColor = MaterialTheme.colorScheme.tertiary,
+                unfocusedIndicatorColor = MaterialTheme.colorScheme.tertiary
+            )
+
+        Scaffold(
+            topBar = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(onClick = { nav.goBack() }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Go back")
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = "Done",
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                        modifier = Modifier.padding(end = 15.dp).clickable {
+                            if (titleState.value.isNotEmpty() && descriptionState.value.isNotEmpty() && locationState.value.isNotEmpty() && priceText.isNotEmpty() && url.value.isNotEmpty()) {
+                                eventViewModel.editEvent(
+                                    event!!.copy(
+                                        title = titleState.value,
+                                        description = descriptionState.value,
+                                        location = selectedLocation.value!!,
+                                        date = pickedDate.value,
+                                        time = pickedTime.value,
+                                        price = price,
+                                        url = url.value,
+                                        tags = tags.value,
+                                        images = imageUri?.let { listOf(it.toString()) } ?: event!!.images
+                                    )
+                                )
+                                nav.goBack()
+                            }
+                        }
+                    )
+                }
+            },
+            bottomBar = {
+                BottomNavigationMenu(
+                    onTabSelect = { selectedTab ->
+                        nav.navigateTo(TOP_LEVEL_DESTINATIONS.first { it.route == selectedTab })
+                    },
+                    tabList = TOP_LEVEL_DESTINATIONS,
+                    selectedItem = Route.PROFILE
+                )
+            },
+            content = { innerPadding ->
+                Box(modifier = Modifier.padding(innerPadding)) {
+                    Column(
+                        modifier = Modifier.padding(start = 15.dp, end = 15.dp)
+                            .verticalScroll(rememberScrollState(0))
+                            .fillMaxSize(),
+                        verticalArrangement = Arrangement.Top,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.gomeet_logo),
+                            contentDescription = "Event picture",
+                            modifier = Modifier.padding(start = 15.dp, end = 15.dp, top = 30.dp, bottom = 15.dp)
+                                .width(101.dp)
+                                .height(101.dp)
+                                .clickable { imagePickerLauncher.launch("image/*") }
+                                .clip(CircleShape)
+                                .background(color = MaterialTheme.colorScheme.background)
+                                .align(Alignment.CenterHorizontally)
+                                .testTag("Event Picture"),
+                            contentScale = ContentScale.Crop
+                        )
+
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        TextField(
+                            value = titleState.value,
+                            onValueChange = { newValue -> titleState.value = newValue },
+                            label = { Text("Title") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = textFieldColors
+                        )
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        TextField(
+                            value = descriptionState.value,
+                            onValueChange = { newValue -> descriptionState.value = newValue },
+                            label = { Text("Description") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = textFieldColors
+                        )
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        LocationField(selectedLocation, locationState, eventViewModel)
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        DateTimePicker(pickedTime = pickedTime, pickedDate = pickedDate)
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        TextField(
+                            value = priceText,
+                            onValueChange = { newVal ->
+                                priceText = newVal
+                                newVal.toDoubleOrNull()?.let { price = it }
+                            },
+                            label = { Text("Price") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = textFieldColors
+                        )
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        TextField(
+                            value = url.value,
+                            onValueChange = { newVal -> url.value = newVal },
+                            label = { Text("Link") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = textFieldColors
+                        )
+                        Spacer(modifier = Modifier.size(16.dp))
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(top = 15.dp, bottom = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Edit Tags",
+                                color = MaterialTheme.colorScheme.onBackground,
+                                fontStyle = FontStyle.Normal,
+                                fontWeight = FontWeight.Normal,
+                                fontFamily = FontFamily.Default,
+                                textAlign = TextAlign.Start,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Icon(
+                                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                                null,
+                                modifier = Modifier.clickable { showPopup.value = true }
+                                    .testTag("EditTagsButton")
+                            )
+                        }
+                    }
+                }
+
+                if (showPopup.value) {
+                    Popup(
+                        alignment = Alignment.Center,
+                        onDismissRequest = { showPopup.value = !showPopup.value }
+                    ) {
+                        TagsSelector("Edit Tags", tags) {
+                            showPopup.value = false
+                        }
+                    }
+                }
+            }
+        )
+    } else {
+        // Display loading or error state
+        Text("Loading event details...")
+    }
+}

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EditEvent.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -81,6 +82,7 @@ fun EditEvent(
 ) {
   val context = LocalContext.current
   val coroutineScope = rememberCoroutineScope()
+    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
 
   var event by remember { mutableStateOf<Event?>(null) }
   var profilePictureUrl by remember { mutableStateOf<String?>(null) }
@@ -229,31 +231,33 @@ fun EditEvent(
                               .testTag("Event Picture"),
                       contentScale = ContentScale.Crop)
 
-                  Spacer(modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   TextField(
                       value = titleState.value,
                       onValueChange = { newValue -> titleState.value = newValue },
                       label = { Text("Title") },
                       singleLine = true,
-                      modifier = Modifier.fillMaxWidth(),
+                      modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
-                  Spacer(modifier = Modifier.size(16.dp))
+
+                Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   TextField(
                       value = descriptionState.value,
                       onValueChange = { newValue -> descriptionState.value = newValue },
                       label = { Text("Description") },
                       singleLine = true,
-                      modifier = Modifier.fillMaxWidth(),
+                      modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
-                  Spacer(modifier = Modifier.size(16.dp))
+
+                Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   LocationField(selectedLocation, locationState, eventViewModel)
-                  Spacer(modifier = Modifier.size(16.dp))
+
+                Spacer(modifier = Modifier.height(screenHeight / 30))
 
                   DateTimePicker(pickedTime = pickedTime, pickedDate = pickedDate)
-                  Spacer(modifier = Modifier.size(16.dp))
 
                   TextField(
                       value = priceText,
@@ -263,21 +267,23 @@ fun EditEvent(
                       },
                       label = { Text("Price") },
                       singleLine = true,
-                      modifier = Modifier.fillMaxWidth(),
+                      modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
-                  Spacer(modifier = Modifier.size(16.dp))
+
+                Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   TextField(
                       value = url.value,
                       onValueChange = { newVal -> url.value = newVal },
                       label = { Text("Link") },
                       singleLine = true,
-                      modifier = Modifier.fillMaxWidth(),
+                      modifier = Modifier.fillMaxWidth().padding(start = 15.dp, end = 15.dp),
                       colors = textFieldColors)
-                  Spacer(modifier = Modifier.size(16.dp))
+
+                Spacer(modifier = Modifier.height(screenHeight / 80))
 
                   Row(
-                      modifier = Modifier.fillMaxWidth().padding(top = 15.dp, bottom = 10.dp),
+                      modifier = Modifier.fillMaxWidth().padding(start = 15.dp, top = 10.dp),
                       verticalAlignment = Alignment.CenterVertically) {
                         Text(
                             text = "Edit Tags",

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
@@ -237,6 +237,7 @@ fun EventButtons(
         TextButton(
             onClick = {
               eventAction(
+                  nav,
                   currentUser,
                   organiser,
                   eventId,
@@ -354,6 +355,7 @@ private fun FavouriteButton(isFavourite: Boolean) {
  * @param currentEvent The current event
  */
 private fun eventAction(
+    nav: NavigationActions,
     currentUser: GoMeetUser,
     organiser: GoMeetUser,
     eventId: String,
@@ -364,7 +366,7 @@ private fun eventAction(
 ) {
 
   if (organiser.uid == currentUser.uid) {
-    // TODO: GO TO EDIT EVENT PARAMETERS SCREEN
+    nav.navigateToScreen(Route.EDIT_EVENT.replace("{eventId}", eventId))
   } else {
 
     if (!isJoined.value) {

--- a/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
@@ -66,6 +66,7 @@ object Route {
   const val MESSAGE_CHANNELS = "MessageChannel"
   const val CHANNEL = "Channel/{id}"
   const val ADD_FRIEND = "AddFriend"
+    const val EDIT_EVENT = "EditEvent/{eventId}"
 }
 
 val CREATE_ITEMS =
@@ -123,6 +124,8 @@ val SECOND_LEVEL_DESTINATION =
             Route.EDIT_PROFILE, icon = Icons.Default.Person, textId = Route.EDIT_PROFILE),
         TopLevelDestination(
             route = Route.ADD_FRIEND, icon = Icons.Default.Person, textId = Route.ADD_FRIEND),
+        TopLevelDestination(
+            route = Route.EDIT_EVENT, icon = Icons.Default.Person, textId = Route.EDIT_EVENT),
     )
 
 val SETTINGS =

--- a/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
@@ -202,7 +202,8 @@ class NavigationActions(val navController: NavHostController) {
             .replace("{description}", Uri.encode(description))
             .replace("{latitude}", loc.latitude.toString())
             .replace("{longitude}", loc.longitude.toString())
-    navController.navigate(route)
+
+    navController.navigate(route) { popUpTo(Route.EVENTS) { inclusive = false } }
   }
 
   /** Navigates to the previous screen. */

--- a/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
@@ -66,7 +66,7 @@ object Route {
   const val MESSAGE_CHANNELS = "MessageChannel"
   const val CHANNEL = "Channel/{id}"
   const val ADD_FRIEND = "AddFriend"
-    const val EDIT_EVENT = "EditEvent/{eventId}"
+  const val EDIT_EVENT = "EditEvent/{eventId}"
 }
 
 val CREATE_ITEMS =


### PR DESCRIPTION
This PR introduces the implementation of the `Edit Event` screen that we can access from the `EventInfo` screen if we selected an event we created. This is an important feature that will enhance our app to be more userfriendly.
<img width="288" alt="Screenshot 2024-05-21 at 11 11 39 AM" src="https://github.com/SwEnt-Project-G18/SwEntApp/assets/76014476/02446320-afba-4959-83a2-831b469853a1">


The creator of an event can now edit his event by updating the title, description, the image presentation of the Event, the tags, the date and time, the price and the location. The updates are fetching after clicking on the `Done` button and we can see the changes in the `EventInfo` screen. Moreover, the previous information about the fields are kept if the user doesn't click on the `Done` button and we ensure that the fields need to be nonempty for the update to occure.