### PR TITLE
New BottomNavigationBar with Notifications

### DIFF
--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/manageinvites/ManageInvites.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/manageinvites/ManageInvites.kt
@@ -96,7 +96,9 @@ fun ManageInvites(
       if (following.isNotEmpty()) {
         following.forEach {
           val followingUser = userViewModel.getUser(it)
-          followersFollowingList.add(followingUser!!)
+          if (!followers.contains(followingUser!!.uid)) {
+            followersFollowingList.add(followingUser)
+          }
         }
       }
       isLoaded = true
@@ -331,12 +333,12 @@ private fun inviteAction(
  */
 @OptIn(ExperimentalFoundationApi::class)
 private fun pagerWeight(pagerState: PagerState, button: String): FontWeight {
-  if ((pagerState.currentPage == TO_INVITE.ordinal && button == TO_INVITE.formattedName) ||
+  return if ((pagerState.currentPage == TO_INVITE.ordinal && button == TO_INVITE.formattedName) ||
       (pagerState.currentPage == PENDING.ordinal && button == PENDING.formattedName) ||
       (pagerState.currentPage == ACCEPTED.ordinal && button == ACCEPTED.formattedName) ||
       (pagerState.currentPage == REFUSED.ordinal && button == REFUSED.formattedName))
-      return FontWeight.Bold
-  else return FontWeight.Normal
+      FontWeight.Bold
+  else FontWeight.Normal
 }
 
 /**
@@ -357,8 +359,8 @@ fun pendingRequests(
     val possiblePreviousInvitationRefused =
         user.pendingRequests.find { it.eventId == event.eventID && it.status == REFUSED }
 
-    if (user.pendingRequests.contains(possiblePreviousInvitationRefused)) {
-      return user.pendingRequests
+    return if (user.pendingRequests.contains(possiblePreviousInvitationRefused)) {
+      user.pendingRequests
           .map {
             if (it == possiblePreviousInvitationRefused) {
               it.copy(status = PENDING)
@@ -368,7 +370,7 @@ fun pendingRequests(
           }
           .toSet()
     } else {
-      return user.pendingRequests.plus(Invitation(event.eventID, status ?: PENDING))
+      user.pendingRequests.plus(Invitation(event.eventID, status ?: PENDING))
     }
   } else {
     return user.pendingRequests.minus(Invitation(event.eventID, status ?: PENDING))

--- a/app/src/main/java/com/github/se/gomeet/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/navigation/BottomNavigationMenu.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.github.se.gomeet.ui.theme.TranslucentCyan
 
 /**
@@ -50,11 +51,13 @@ fun BottomNavigationMenu(
           },
           label = {
             Text(
-                destination.textId,
+                text = destination.textId,
+                maxLines = 1,
                 style =
                     if (selected)
-                        MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold)
-                    else MaterialTheme.typography.labelLarge)
+                        MaterialTheme.typography.labelLarge.copy(
+                            fontWeight = FontWeight.Bold, fontSize = 12.sp)
+                    else MaterialTheme.typography.labelLarge.copy(fontSize = 12.sp))
           },
           selected = selected,
           onClick = { onTabSelect(destination.route) },
@@ -75,6 +78,6 @@ fun PreviewBottomNavigationMenu() {
   BottomNavigationMenu(
       onTabSelect = {},
       tabList = TOP_LEVEL_DESTINATIONS,
-      selectedItem = Route.CREATE,
+      selectedItem = Route.NOTIFICATIONS,
   )
 }

--- a/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/navigation/NavigationAction.kt
@@ -4,17 +4,15 @@ import android.net.Uri
 import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AccountCircle
-import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material.icons.outlined.AddCircle
 import androidx.compose.material.icons.outlined.DateRange
 import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -98,7 +96,7 @@ val TOP_LEVEL_DESTINATIONS =
         TopLevelDestination(route = Route.TRENDS, icon = Icons.Default.Home, textId = Route.TRENDS),
         TopLevelDestination(
             route = Route.EXPLORE, icon = Icons.Default.Home, textId = Route.EXPLORE),
-        TopLevelDestination(route = Route.CREATE, icon = Icons.Default.Add, textId = Route.CREATE),
+        TopLevelDestination(Route.NOTIFICATIONS, Icons.Default.Notifications, Route.NOTIFICATIONS),
         TopLevelDestination(
             route = Route.PROFILE, icon = Icons.Default.Person, textId = Route.PROFILE))
 
@@ -222,7 +220,7 @@ fun getIconForRoute(route: String): ImageVector {
     Route.EVENTS -> Icons.Outlined.DateRange
     Route.TRENDS -> ImageVector.vectorResource(R.drawable.arrow_trending)
     Route.EXPLORE -> Icons.Outlined.Home
-    Route.CREATE -> Icons.Outlined.AddCircle
+    Route.NOTIFICATIONS -> Icons.Outlined.Notifications
     Route.PROFILE -> Icons.Outlined.Person
     else -> Icons.Outlined.AccountCircle
   }
@@ -239,7 +237,7 @@ fun getIconForSelectedRoute(route: String): ImageVector {
     Route.EVENTS -> Icons.Filled.DateRange
     Route.TRENDS -> ImageVector.vectorResource(R.drawable.arrow_trending)
     Route.EXPLORE -> Icons.Filled.Home
-    Route.CREATE -> Icons.Filled.AddCircle
+    Route.NOTIFICATIONS -> Icons.Filled.Notifications
     Route.PROFILE -> Icons.Filled.Person
     else -> Icons.Filled.AccountCircle
   }


### PR DESCRIPTION
This PR updates the display of the `BottomNavigationBar` by removing the `Create` button to replace it with the `Notifications` button as we think notifications will be used a lot more by the user than the create logic. Now the user can create events with the little + blue button in the `Events` screen. I also fixed the issue #212 concerning the duplicate of user invitations if the user was a follower and was following the current user.