### PR TITLE
fixed empty URL crash

### DIFF
--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/create/CreateEvent.kt
@@ -426,7 +426,7 @@ fun CreateEvent(
                               pickedDate.value,
                               pickedTime.value,
                               price,
-                              urlState.value,
+                              urlState.value.ifEmpty { "https://no_url.com" },
                               invitedParticipants.map { it.uid },
                               listOf(),
                               listOf(),

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.Event
 import com.github.se.gomeet.model.event.Post

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
@@ -133,15 +133,6 @@ fun MyEventInfo(
   var posts by rememberSaveable { mutableStateOf<List<Post>>(emptyList()) }
   val uriHandler = LocalUriHandler.current
   val context = LocalContext.current
-  val urlString = buildAnnotatedString {
-    withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onBackground)) {
-      append("More info at : ")
-    }
-    pushStringAnnotation(tag = "URL", annotation = url)
-    withStyle(style = SpanStyle(color = Color.Blue, textDecoration = TextDecoration.Underline)) {
-      append(url)
-    }
-  }
   var isLoading by remember { mutableStateOf(true) }
 
   LaunchedEffect(Unit) {
@@ -230,23 +221,39 @@ fun MyEventInfo(
 
                   EventDescription(text = description)
                   Spacer(modifier = Modifier.height(10.dp))
-                  ClickableText(
-                      text = urlString,
-                      modifier = Modifier.padding(horizontal = 10.dp).wrapContentSize(),
-                      style = MaterialTheme.typography.bodyLarge,
-                      onClick = { offset ->
-                        urlString
-                            .getStringAnnotations(tag = "URL", start = offset, end = offset)
-                            .firstOrNull()
-                            ?.let {
-                              try {
-                                uriHandler.openUri(url)
-                              } catch (e: Exception) {
-                                Log.e(TAG, "Failed to open URL: $url")
+                  if (url != "https://no_url.com") {
+                    val urlString = buildAnnotatedString {
+                      withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onBackground)) {
+                        append("More info at : ")
+                      }
+                      pushStringAnnotation(tag = "URL", annotation = url)
+                      withStyle(
+                          style =
+                              SpanStyle(
+                                  color = Color.Blue, textDecoration = TextDecoration.Underline)) {
+                            append(url)
+                          }
+                    }
+
+                    ClickableText(
+                        text = urlString,
+                        modifier = Modifier.padding(horizontal = 10.dp).wrapContentSize(),
+                        style = MaterialTheme.typography.bodyLarge,
+                        onClick = { offset ->
+                          urlString
+                              .getStringAnnotations(tag = "URL", start = offset, end = offset)
+                              .firstOrNull()
+                              ?.let {
+                                try {
+                                  uriHandler.openUri(url)
+                                } catch (e: Exception) {
+                                  Log.e(TAG, "Failed to open URL: $url")
+                                }
                               }
-                            }
-                      })
-                  Spacer(modifier = Modifier.height(20.dp))
+                        })
+
+                    Spacer(modifier = Modifier.height(20.dp))
+                  }
                   MapViewComposable(loc = loc)
                   if (addPost) {
                     Spacer(modifier = Modifier.height(screenHeight / 80))

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/MyEventInfo.kt
@@ -222,7 +222,7 @@ fun MyEventInfo(
 
                   EventDescription(text = description)
                   Spacer(modifier = Modifier.height(10.dp))
-<<<<<<< S10-FixNavigation
+
                   if (url != "https://no_url.com") {
                     val urlString = buildAnnotatedString {
                       withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.onBackground)) {
@@ -256,47 +256,7 @@ fun MyEventInfo(
 
                     Spacer(modifier = Modifier.height(20.dp))
                   }
-=======
 
-                  val annotatedString = buildAnnotatedString {
-                    withStyle(
-                        style =
-                            SpanStyle(
-                                color = MaterialTheme.colorScheme.onBackground, fontSize = 16.sp)) {
-                          append("More info at: ")
-                        }
-                    withStyle(
-                        style =
-                            SpanStyle(
-                                color = MaterialTheme.colorScheme.outlineVariant,
-                                fontSize = 16.sp)) {
-                          append(url)
-                        }
-                    addStringAnnotation(
-                        tag = "URL",
-                        annotation = url,
-                        start = "More info at: ".length,
-                        end = urlString.length)
-                  }
-
-                  ClickableText(
-                      text = annotatedString,
-                      modifier = Modifier.padding(horizontal = 10.dp).wrapContentSize(),
-                      onClick = { offset ->
-                        annotatedString
-                            .getStringAnnotations(tag = "URL", start = offset, end = offset)
-                            .firstOrNull()
-                            ?.let {
-                              try {
-                                uriHandler.openUri(it.item)
-                              } catch (e: Exception) {
-                                Log.e("ClickableText", "Failed to open URL: ${it.item}")
-                              }
-                            }
-                      })
-
-                  Spacer(modifier = Modifier.height(20.dp))
->>>>>>> main
                   MapViewComposable(loc = loc)
                   if (addPost) {
                     Spacer(modifier = Modifier.height(screenHeight / 80))


### PR DESCRIPTION
We fixed the issue #260. At first I thought problem was in the Navigation, but the problem was that the app crashes when trying to access an `Event` that has an empty URL. To solve the issue, we just give at the creation of an `Event`, a default URL in case the `Event` to be created has an empty URL. 