### PR TITLE
Fixed issues with events filtering and joining/leaving/editing past events

### DIFF
--- a/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd2.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd2.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.github.se.gomeet.MainActivity
+import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.location.Location
 import com.github.se.gomeet.screens.EventInfoScreen
 import com.github.se.gomeet.screens.ExploreScreen
@@ -30,6 +31,7 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.kakao.common.utilities.getResourceString
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.concurrent.TimeUnit
@@ -211,7 +213,9 @@ class EndToEndTest2 : TestCase() {
     ComposeScreen.onComposeScreen<TrendsScreen>(composeTestRule) {
       step("View the info page of an event by clicking on it") {
         composeTestRule.waitForIdle()
-        composeTestRule.onAllNodesWithText("Trends")[0].performClick()
+        composeTestRule
+            .onAllNodesWithText(getResourceString(R.string.recommended))[0]
+            .performClick()
         composeTestRule.waitUntil(timeoutMillis = 10000) {
           composeTestRule.onAllNodesWithTag("Card")[0].isDisplayed()
         }

--- a/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd3.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/endtoend/EndToEnd3.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.github.se.gomeet.MainActivity
+import com.github.se.gomeet.R
 import com.github.se.gomeet.model.event.location.Location
 import com.github.se.gomeet.screens.EventInfoScreen
 import com.github.se.gomeet.screens.EventsScreen
@@ -30,6 +31,7 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.kakao.common.utilities.getResourceString
 import java.time.LocalDate
 import java.time.LocalTime
 import java.util.concurrent.TimeUnit
@@ -203,7 +205,10 @@ class EndToEndTest3 : TestCase() {
           composeTestRule.onNodeWithTag("EventHeader").isDisplayed()
         }
         composeTestRule.onNodeWithText("Edit My Event").assertIsDisplayed().assertHasClickAction()
-        composeTestRule.onNodeWithText("Handle Participants").assertIsDisplayed().performClick()
+        composeTestRule
+            .onNodeWithText(getResourceString(R.string.participants_button))
+            .assertIsDisplayed()
+            .performClick()
         composeTestRule.waitForIdle()
       }
     }
@@ -233,7 +238,10 @@ class EndToEndTest3 : TestCase() {
             composeTestRule.onNodeWithTag("EventHeader").isDisplayed()
           }
           composeTestRule.onNodeWithText("Edit My Event").assertIsDisplayed().assertHasClickAction()
-          composeTestRule.onNodeWithText("Handle Participants").assertIsDisplayed().performClick()
+          composeTestRule
+              .onNodeWithText(getResourceString(R.string.participants_button))
+              .assertIsDisplayed()
+              .performClick()
           composeTestRule.waitForIdle()
         }
       }

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/TrendsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/TrendsTest.kt
@@ -8,9 +8,11 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gomeet.R
 import com.github.se.gomeet.ui.navigation.NavigationActions
 import com.github.se.gomeet.viewmodel.EventViewModel
 import com.github.se.gomeet.viewmodel.UserViewModel
+import io.github.kakaocup.kakao.common.utilities.getResourceString
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,7 +39,10 @@ class TrendsTest {
 
     // Verify that the ui is correctly displayed
     composeTestRule.onNodeWithText("Sort").assertIsDisplayed().performClick()
-    composeTestRule.onNodeWithText("Popularity").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithText(getResourceString(R.string.tag_sort))
+        .assertIsDisplayed()
+        .performClick()
     composeTestRule.onNodeWithText("Sort").performClick()
     composeTestRule.onNodeWithText("Name").assertIsDisplayed().performClick()
     composeTestRule.onNodeWithText("Sort").performClick()

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/NotificationsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/NotificationsTest.kt
@@ -114,7 +114,7 @@ class NotificationsTest {
     composeTestRule.onNodeWithText("Invitations").assertIsDisplayed().assertHasClickAction()
 
     // Test that the invitation notification widget is correctly displayed
-    composeTestRule.onNodeWithText("30/3/2026", substring = true).assertIsDisplayed()
+    composeTestRule.onNodeWithText("30/03/2026", substring = true).assertIsDisplayed()
     composeTestRule.onNodeWithText("Accept").assertIsDisplayed().assertHasClickAction()
     composeTestRule.onNodeWithText("Decline").assertIsDisplayed().performClick()
   }

--- a/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/ProfileEventListTest.kt
+++ b/app/src/androidTest/java/com/github/se/gomeet/ui/mainscreens/profile/ProfileEventListTest.kt
@@ -124,7 +124,7 @@ class ProfileEventListTest {
     // Test that the ui is correctly displayed
     composeTestRule.onNodeWithTag("EventsListItems").assertIsDisplayed()
     composeTestRule.onNodeWithTag("EventsListHeader").assertIsDisplayed()
-    composeTestRule.onNodeWithText("2026-01-01").assertIsDisplayed()
+    composeTestRule.onNodeWithText(event.getDateString()).assertIsDisplayed()
     composeTestRule.onNodeWithContentDescription("description").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/github/se/gomeet/model/event/Event.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/event/Event.kt
@@ -119,9 +119,9 @@ data class Event(
    * @return The string representation of the date.
    */
   fun getDateString(): String {
-    val date =
-        if (this.date == LocalDate.now()) "Today"
-        else "${this.date.dayOfMonth}/${this.date.monthValue}/${this.date.year}"
+    val day = if (this.date.dayOfMonth < 9) "0${this.date.dayOfMonth}" else this.date.dayOfMonth
+    val month = if (this.date.monthValue < 9) "0${this.date.monthValue}" else this.date.monthValue
+    val date = if (this.date == LocalDate.now()) "Today" else "$day/$month/${this.date.year}"
     return date
   }
 

--- a/app/src/main/java/com/github/se/gomeet/model/event/Event.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/event/Event.kt
@@ -133,4 +133,20 @@ data class Event(
   fun momentToString(): String {
     return "${this.getDateString()} at ${this.getTimeString()}"
   }
+
+  fun display(userId: String): Boolean {
+    return !this.isPastEvent() &&
+        (this.creator == userId ||
+            this.public ||
+            this.pendingParticipants.contains(userId) ||
+            this.participants.contains(userId))
+  }
+
+  fun historyDisplay(userId: String): Boolean {
+    return this.isPastEvent() &&
+        (this.creator == userId ||
+            this.public ||
+            this.pendingParticipants.contains(userId) ||
+            this.participants.contains(userId))
+  }
 }

--- a/app/src/main/java/com/github/se/gomeet/model/event/Event.kt
+++ b/app/src/main/java/com/github/se/gomeet/model/event/Event.kt
@@ -108,8 +108,8 @@ data class Event(
    * @return The string representation of the time.
    */
   fun getTimeString(): String {
-    val minutes = if (this.time.minute < 9) "0${this.time.minute}" else this.time.minute
-    val hours = if (this.time.hour < 9) "0${this.time.hour}" else this.time.hour
+    val minutes = if (this.time.minute <= 9) "0${this.time.minute}" else this.time.minute
+    val hours = if (this.time.hour <= 9) "0${this.time.hour}" else this.time.hour
     return "${hours}:${minutes}"
   }
 
@@ -119,8 +119,8 @@ data class Event(
    * @return The string representation of the date.
    */
   fun getDateString(): String {
-    val day = if (this.date.dayOfMonth < 9) "0${this.date.dayOfMonth}" else this.date.dayOfMonth
-    val month = if (this.date.monthValue < 9) "0${this.date.monthValue}" else this.date.monthValue
+    val day = if (this.date.dayOfMonth <= 9) "0${this.date.dayOfMonth}" else this.date.dayOfMonth
+    val month = if (this.date.monthValue <= 9) "0${this.date.monthValue}" else this.date.monthValue
     val date = if (this.date == LocalDate.now()) "Today" else "$day/$month/${this.date.year}"
     return date
   }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
@@ -39,10 +39,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat.getString
 import coil.compose.rememberAsyncImagePainter
 import com.github.se.gomeet.R
 import com.github.se.gomeet.model.Tag
@@ -116,7 +118,7 @@ fun Trends(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(start = screenWidth / 15, top = screenHeight / 30)) {
               Text(
-                  text = "Recommended",
+                  text = getString(LocalContext.current, R.string.recommended),
                   color = MaterialTheme.colorScheme.onBackground,
                   style =
                       MaterialTheme.typography.headlineMedium.copy(
@@ -317,7 +319,7 @@ fun SortButton(eventList: MutableList<Event>, userTags: List<Tag>) {
                     .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.secondaryContainer)) {
               DropdownMenuItem(
-                  text = { Text("By common tags") },
+                  text = { Text(getString(LocalContext.current, R.string.tag_sort)) },
                   onClick = {
                     EventViewModel.sortEvents(Tag.tagListToString(userTags), eventList)
                     selectedOption = DEFAULT

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
@@ -104,10 +104,8 @@ fun Trends(
       } else {
         Log.e(TAG, "Current user is null")
       }
-      val allEvents = eventViewModel.getAllEvents()!!.filter { !it.isPastEvent() }
-      if (allEvents.isNotEmpty()) {
-        eventList.addAll(allEvents)
-      }
+      eventList.addAll(eventViewModel.getAllEvents()!!.filter { it.display(currentUserId) })
+
       eventsLoaded.value = true
     }
   }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
@@ -317,7 +317,7 @@ fun SortButton(eventList: MutableList<Event>, userTags: List<Tag>) {
                     .fillMaxWidth()
                     .background(MaterialTheme.colorScheme.secondaryContainer)) {
               DropdownMenuItem(
-                  text = { Text("Popularity") },
+                  text = { Text("By common tags") },
                   onClick = {
                     EventViewModel.sortEvents(Tag.tagListToString(userTags), eventList)
                     selectedOption = DEFAULT

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/Trends.kt
@@ -116,7 +116,7 @@ fun Trends(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(start = screenWidth / 15, top = screenHeight / 30)) {
               Text(
-                  text = "Trends",
+                  text = "Recommended",
                   color = MaterialTheme.colorScheme.onBackground,
                   style =
                       MaterialTheme.typography.headlineMedium.copy(

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat.getString
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.github.se.gomeet.R
@@ -335,7 +336,7 @@ fun EventButtons(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         contentColor = MaterialTheme.colorScheme.tertiary)) {
                   if (buttons == 0) {
-                    Text("Manage Participants")
+                    Text(getString(LocalContext.current, R.string.participants_button))
                   } else {
                     Text("Decline Invite")
                   }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
@@ -327,6 +327,7 @@ fun EventButtons(
                     isJoined.value = false
                   }
                 },
+                enabled = !event.isPastEvent(),
                 shape = RoundedCornerShape(10.dp),
                 modifier = Modifier.weight(1f),
                 colors =

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/events/EventInfo.kt
@@ -279,6 +279,7 @@ fun EventButtons(
         modifier = Modifier.fillMaxWidth().testTag("EventButton"),
         horizontalArrangement = Arrangement.SpaceBetween) {
           TextButton(
+              enabled = !event.isPastEvent(),
               onClick = {
                 eventAction(
                     nav,
@@ -333,7 +334,7 @@ fun EventButtons(
                         containerColor = MaterialTheme.colorScheme.primaryContainer,
                         contentColor = MaterialTheme.colorScheme.tertiary)) {
                   if (buttons == 0) {
-                    Text("Handle Participants")
+                    Text("Manage Participants")
                   } else {
                     Text("Decline Invite")
                   }

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/explore/Explore.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/explore/Explore.kt
@@ -88,11 +88,11 @@ fun Explore(nav: NavigationActions, eventViewModel: EventViewModel) {
     } else {
       locationPermissionLauncher.launch(locationPermissions)
     }
-
+    val currentUser = eventViewModel.currentUID!!
     val allEvents = eventViewModel.getAllEvents()
     if (allEvents != null) {
-      eventList.value = allEvents.filter { e -> !e.isPastEvent() }
-      nonFilteredEvents.value = allEvents.filter { e -> !e.isPastEvent() }
+      eventList.value = allEvents.filter { e -> e.display(currentUser) }
+      nonFilteredEvents.value = allEvents.filter { e -> e.display(currentUser) }
     }
 
     // wait for user input

--- a/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/ProfileEventList.kt
+++ b/app/src/main/java/com/github/se/gomeet/ui/mainscreens/profile/ProfileEventList.kt
@@ -125,7 +125,7 @@ fun ProfileEventsList(
                       color = MaterialTheme.colorScheme.onBackground,
                       style = MaterialTheme.typography.bodyLarge)
                   Text(
-                      text = event.date.toString(),
+                      text = event.getDateString(),
                       color = MaterialTheme.colorScheme.onBackground,
                       style =
                           MaterialTheme.typography.bodyLarge.copy(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
     <string name="app_name">GoMeet</string>
     <string name ="chat_api_key">e43k9kfvgyze</string>
     <string name="title_activity_channel">ChannelActivity</string>
+    <string name="recommended">Recommended</string>
+    <string name="participants_button">"Manage Participants"</string>
+    <string name="tag_sort">By common tags</string>
 </resources>


### PR DESCRIPTION
- Fixes #271 #269 
- Fixed date and time format being different in profile compared to everywhere else (bug hadn't been added to issues yet)
- Renamed Trends to Recommended and the Popularity sorting to By common tags, since those are more accurate names
- Added renamed strings to resource manager to avoid "magic strings"
- Updated tests when necessary